### PR TITLE
docs: add composable multi-exception guide and execution timing details

### DIFF
--- a/website/docs/concepts/hibernateplan.md
+++ b/website/docs/concepts/hibernateplan.md
@@ -32,9 +32,13 @@ schedule:
   timezone: "Asia/Jakarta"
   offHours:
     - start: "20:00"       # HH:MM format (24-hour)
-      end: "06:00"         # Next day when end < start
+      end: "06:00"         # Next eligible day when end < start
       daysOfWeek: ["MON", "TUE", "WED", "THU", "FRI"]
 ```
+
+All executions — both hibernation and wakeup — are bounded to `daysOfWeek`. Wakeup only triggers on days listed in the schedule. For example, Friday 20:00 hibernation does not wake up Saturday 06:00; resources stay hibernated until Monday 06:00.
+
+The controller applies a schedule buffer (default: 1 minute) and safety buffer (10 seconds) to every execution, so actual actions occur up to **1m 10s** after the nominal schedule time. See [Execution Timing](../user-guides/schedule-boundaries.md#execution-timing-schedule-buffer-and-safety-buffer) for details.
 
 ### Multiple Windows
 

--- a/website/docs/concepts/schedule-exceptions.md
+++ b/website/docs/concepts/schedule-exceptions.md
@@ -12,21 +12,24 @@ Adds additional hibernation windows to the base schedule (OR-union):
 apiVersion: hibernator.ardikabs.com/v1alpha1
 kind: ScheduleException
 metadata:
-  name: weekend-hibernation
+  name: wednesday-holiday
   namespace: hibernator-system
 spec:
   planRef:
     name: dev-plan
   type: extend
-  validFrom: "2026-02-10T00:00:00Z"
-  validUntil: "2026-02-15T23:59:59Z"
+  validFrom: "2026-02-11T00:00:00Z"
+  validUntil: "2026-02-11T23:59:59Z"
   windows:
-    - start: "00:00"
-      end: "23:59"
-      daysOfWeek: ["SAT", "SUN"]
+    - start: "06:00"
+      end: "20:00"
+      daysOfWeek: ["WED"]
 ```
 
-**Use case**: Extend hibernation to weekends during a quiet period.
+**Use case**: A weekday public holiday falls on Wednesday. The base schedule (20:00–06:00 MON–FRI) would wake resources at 06:00, but nobody is working. The extend exception fills the daytime gap (06:00–20:00), creating continuous hibernation from Tuesday 20:00 through Wednesday 20:00.
+
+!!! note
+    If your base schedule uses `daysOfWeek: ["MON", "TUE", "WED", "THU", "FRI"]`, weekends are already fully hibernated — wakeup only triggers on listed days. There is no need to extend for weekends.
 
 ### Suspend
 
@@ -36,24 +39,24 @@ Prevents hibernation during specified windows (carve-out):
 apiVersion: hibernator.ardikabs.com/v1alpha1
 kind: ScheduleException
 metadata:
-  name: maintenance-window
+  name: japan-team-debug
   namespace: hibernator-system
 spec:
   planRef:
-    name: prod-plan
+    name: dev-plan
   type: suspend
-  validFrom: "2026-02-01T20:00:00Z"
-  validUntil: "2026-02-02T02:00:00Z"
+  validFrom: "2026-02-11T00:00:00Z"
+  validUntil: "2026-02-11T23:59:59Z"
   leadTime: "1h"
   windows:
-    - start: "21:00"
-      end: "02:00"
-      daysOfWeek: ["SAT"]
+    - start: "20:00"
+      end: "23:59"
+      daysOfWeek: ["WED"]
 ```
 
-**Use case**: Keep resources awake during a maintenance window or incident.
+**Use case**: The base schedule hibernates resources at 20:00 Asia/Jakarta, but a team in Bangalore (IST/UTC+5:30) needs to continue debugging on Wednesday might. The suspend exception holds off hibernation from 20:00–23:59, keeping resources alive past the normal cutoff.
 
-The `leadTime` field creates a buffer before the suspension window. With `leadTime: "1h"`, the controller won't start a new hibernation cycle within 1 hour before the suspension begins.
+The `leadTime` field creates a buffer before the suspension window. With `leadTime: "1h"`, the controller won't start a new hibernation cycle within 1 hour before the suspension begins (i.e., from 19:00 onward).
 
 ### Replace
 
@@ -90,24 +93,53 @@ spec:
 
 ## Composable Exceptions
 
-You can combine compatible exception types on the same plan:
+Multiple exceptions can coexist on the same plan. Whether they are allowed depends on two factors: whether their **schedule windows collide** (overlap in time-of-day on shared days), and whether their **types** form a permitted pair.
 
-| Combination | Allowed | Behavior |
-|-------------|---------|----------|
-| extend + suspend | Yes | Extend adds windows, suspend carves out from result |
-| extend + replace | No | Replace overrides everything |
-| suspend + replace | No | Replace overrides everything |
-| extend + extend | No | Only one extend per plan at a time |
+### Non-Colliding Windows (Any Type Combination)
 
-The controller uses `mergeByType` semantics to combine compatible exception pairs.
+If two exceptions target different days or non-overlapping time ranges, they are always allowed regardless of type:
+
+| Combination | Windows Collide? | Allowed | Behavior |
+|-------------|-----------------|---------|----------|
+| extend + extend | No | Yes | Windows merged during evaluation |
+| suspend + suspend | No | Yes | Windows merged during evaluation |
+| replace + replace | No | Yes | Each replaces for its own days |
+| Any cross-type pair | No | Yes | Each applies independently |
+
+### Colliding Windows (Type Pairing Rules)
+
+When windows do collide, only certain cross-type combinations are permitted:
+
+| Combination | Windows Collide? | Allowed | Behavior |
+|-------------|-----------------|---------|----------|
+| extend + suspend | Yes | Yes | Suspend carves out from the extended schedule |
+| replace + extend | Yes | Yes | Replace becomes the new base; extend adds on top |
+| replace + suspend | Yes | Yes | Replace becomes the new base; suspend carves out |
+| extend + extend | Yes | No | Redundant — merge into a single extend exception |
+| suspend + suspend | Yes | No | Redundant — merge into a single suspend exception |
+| replace + replace | Yes | No | Ambiguous — which replacement wins? |
+
+### Evaluation Order
+
+When multiple exceptions are active, the controller composes them in this order:
+
+1. **Replace** (if present): overwrites the base schedule entirely
+2. **Extend**: adds windows on top of the effective base (original or replaced)
+3. **Suspend**: carves out windows from the effective result
+
+The controller uses `mergeByType` semantics — windows of the same type are merged before cross-type composition.
+
+For practical scenarios showing how to combine exceptions (extend + suspend, replace + extend, replace + suspend), see the [Composing Multiple Exceptions](../user-guides/composing-multiple-exceptions.md) operational guide.
 
 ## Validation Rules
 
 - `validUntil` must be after `validFrom`
 - At least one window must be specified
 - `leadTime` is only valid for `suspend` type exceptions
-- Temporal overlap between Active exceptions on the same plan is prevented
-- The controller automatically transitions states based on time
+- **Window-level overlap detection**: exceptions with overlapping validity periods are checked for schedule window collisions (time-of-day + day-of-week), not just temporal overlap
+- Same-type exceptions with colliding windows are rejected (merge into one instead)
+- Cross-type exceptions with colliding windows are allowed for permitted pairs (see table above)
+- The controller automatically transitions exception states based on time
 
 ## See Also
 

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -34,7 +34,7 @@ The controller re-evaluates the schedule on startup and takes the appropriate ac
 
 ### How do overnight windows work?
 
-When `end` is earlier than `start` (e.g., 20:00–06:00), the window spans midnight into the next day. The `daysOfWeek` refers to the day the window starts.
+When `end` is earlier than `start` (e.g., 20:00–06:00), the window spans midnight. Both hibernation and wakeup are bounded to the days listed in `daysOfWeek`. For example, with `daysOfWeek: ["MON", "TUE", "WED", "THU", "FRI"]` and a 20:00–06:00 window, Friday’s hibernation does not wake up Saturday — resources stay hibernated until **Monday 06:00**, the next listed day.
 
 ## Execution
 

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -139,11 +139,14 @@ kubectl logs -n hibernator-system -l hibernator/plan=dev-offhours
 
 ## What Happens Next?
 
-- At **20:00 Asia/Jakarta**, the controller evaluates the schedule and begins shutdown
+- At **20:00 Asia/Jakarta** on a listed day, the controller evaluates the schedule and begins shutdown
 - Targets are executed following DAG order: `dev-karpenter` and `dev-db` first (parallel), then `dev-eks-nodegroups`
 - Restore metadata is captured and persisted in ConfigMaps
-- At **06:00 Asia/Jakarta**, the controller triggers wakeup in reverse order
+- At **06:00 Asia/Jakarta** on the next listed day, the controller triggers wakeup in reverse order
 - Resources are restored using the saved metadata
+
+!!! note
+    Wakeup only triggers on days in `daysOfWeek`. With weekday-only schedules (MON–FRI), Friday 20:00 hibernation stays until **Monday 06:00** — Saturday and Sunday are not execution days.
 
 ## Next Steps
 

--- a/website/docs/user-guides/composing-multiple-exceptions.md
+++ b/website/docs/user-guides/composing-multiple-exceptions.md
@@ -1,0 +1,281 @@
+# Composing Multiple Exceptions
+
+This guide covers combining multiple `ScheduleException` resources on the same `HibernatePlan` — when it's allowed, how the controller composes them, and practical scenarios.
+
+## When You Need Multiple Exceptions
+
+A single exception handles one deviation. But real operations often require layered adjustments:
+
+- A **holiday replace** defines a special schedule, but you also need to **suspend** a window for a release deployment
+- An **extend** covers a public holiday, but a team still needs resources alive for part of that day (**suspend** carve-out)
+- Two separate teams request independent **extend** windows on different days
+
+## Compatibility Rules
+
+Whether two exceptions can coexist depends on two factors: whether their **schedule windows collide** (overlap in time-of-day on shared days), and whether their **types** form a permitted pair.
+
+### Non-Colliding Windows
+
+If two exceptions target different days or non-overlapping time ranges, they are **always allowed** regardless of type:
+
+```yaml
+# extend-morning: 06:00–12:00 on WED
+# extend-afternoon: 14:00–20:00 on THU
+# → No collision. Both accepted and merged during evaluation.
+```
+
+### Colliding Windows
+
+When windows overlap in time on the same day, only certain type combinations are permitted:
+
+| Combination | Allowed | Why |
+|-------------|---------|-----|
+| extend + suspend | Yes | Suspend carves out from extended hibernation |
+| replace + extend | Yes | Replace becomes the new base; extend adds on top |
+| replace + suspend | Yes | Replace becomes the new base; suspend carves out |
+| extend + extend | No | Redundant — merge into a single extend exception |
+| suspend + suspend | No | Redundant — merge into a single suspend exception |
+| replace + replace | No | Ambiguous — which replacement wins? |
+
+!!! tip
+    If you need two overlapping windows of the same type, combine them into a single exception with multiple windows instead.
+
+## Composition Order
+
+When multiple exceptions are active, the controller applies them in a deterministic order:
+
+1. **Replace** (if present): overwrites the base schedule entirely
+2. **Extend**: adds windows on top of the effective base (original or replaced)
+3. **Suspend**: carves out windows from the effective result
+
+This means a suspend always wins over extend and replace for the time ranges it covers.
+
+## Scenarios
+
+### Extend + Suspend: Holiday with a Maintenance Carve-Out
+
+**Situation**: Wednesday is a public holiday. You want resources hibernated all day (extend), but the SRE team needs a 2-hour maintenance window in the afternoon (suspend).
+
+Base schedule: `20:00–06:00` weekdays.
+
+```yaml
+# 1. Extend: keep resources hibernated during the daytime gap
+apiVersion: hibernator.ardikabs.com/v1alpha1
+kind: ScheduleException
+metadata:
+  name: wednesday-holiday
+  namespace: hibernator-system
+spec:
+  planRef:
+    name: dev-plan
+  type: extend
+  validFrom: "2026-02-11T00:00:00Z"
+  validUntil: "2026-02-11T23:59:59Z"
+  windows:
+    - start: "06:00"
+      end: "20:00"
+      daysOfWeek: ["WED"]
+```
+
+```yaml
+# 2. Suspend: carve out a maintenance window
+apiVersion: hibernator.ardikabs.com/v1alpha1
+kind: ScheduleException
+metadata:
+  name: wednesday-maintenance
+  namespace: hibernator-system
+spec:
+  planRef:
+    name: dev-plan
+  type: suspend
+  validFrom: "2026-02-11T00:00:00Z"
+  validUntil: "2026-02-11T23:59:59Z"
+  leadTime: "30m"
+  windows:
+    - start: "14:00"
+      end: "16:00"
+      daysOfWeek: ["WED"]
+```
+
+**Result on Wednesday**:
+
+- 00:00–06:00: Hibernated (base overnight window)
+- 06:00–13:30: Hibernated (extend fills daytime gap; leadTime prevents hibernate after 13:30)
+- 13:30–16:00: Awake (leadTime buffer + suspend carve-out)
+- 16:00–20:00: Hibernated (extend resumes)
+- 20:00–06:00: Hibernated (base overnight window)
+
+### Replace + Extend: Holiday Week with Extra Coverage
+
+**Situation**: During a holiday week, you replace the base schedule with a reduced window. But Wednesday has a special all-day shutdown need.
+
+```yaml
+# 1. Replace: holiday week schedule (hibernate 22:00–08:00 only)
+apiVersion: hibernator.ardikabs.com/v1alpha1
+kind: ScheduleException
+metadata:
+  name: holiday-reduced
+  namespace: hibernator-system
+spec:
+  planRef:
+    name: prod-plan
+  type: replace
+  validFrom: "2026-12-24T00:00:00Z"
+  validUntil: "2026-12-31T23:59:59Z"
+  windows:
+    - start: "22:00"
+      end: "08:00"
+      daysOfWeek: ["MON", "TUE", "WED", "THU", "FRI"]
+```
+
+```yaml
+# 2. Extend: full day off on Christmas Day (Wednesday)
+apiVersion: hibernator.ardikabs.com/v1alpha1
+kind: ScheduleException
+metadata:
+  name: christmas-day-off
+  namespace: hibernator-system
+spec:
+  planRef:
+    name: prod-plan
+  type: extend
+  validFrom: "2026-12-25T00:00:00Z"
+  validUntil: "2026-12-25T23:59:59Z"
+  windows:
+    - start: "08:00"
+      end: "22:00"
+      daysOfWeek: ["WED"]
+```
+
+**Result on Christmas Day**:
+
+- The **replace** sets the base to 22:00–08:00 (instead of the normal schedule)
+- The **extend** fills 08:00–22:00, creating continuous hibernation for the full day
+- Other holiday weekdays follow the relaxed 22:00–08:00 schedule
+
+### Replace + Suspend: Holiday Schedule with a Release Window
+
+**Situation**: During a holiday week with a custom schedule, you need resources alive for a Friday afternoon release.
+
+```yaml
+# 1. Replace: holiday schedule (hibernate 18:00–10:00)
+apiVersion: hibernator.ardikabs.com/v1alpha1
+kind: ScheduleException
+metadata:
+  name: holiday-schedule
+  namespace: hibernator-system
+spec:
+  planRef:
+    name: prod-plan
+  type: replace
+  validFrom: "2026-12-24T00:00:00Z"
+  validUntil: "2026-12-31T23:59:59Z"
+  windows:
+    - start: "18:00"
+      end: "10:00"
+      daysOfWeek: ["MON", "TUE", "WED", "THU", "FRI"]
+```
+
+```yaml
+# 2. Suspend: keep resources alive for Friday release
+apiVersion: hibernator.ardikabs.com/v1alpha1
+kind: ScheduleException
+metadata:
+  name: friday-release
+  namespace: hibernator-system
+spec:
+  planRef:
+    name: prod-plan
+  type: suspend
+  validFrom: "2026-12-26T00:00:00Z"
+  validUntil: "2026-12-26T23:59:59Z"
+  leadTime: "1h"
+  windows:
+    - start: "18:00"
+      end: "22:00"
+      daysOfWeek: ["FRI"]
+```
+
+**Result on Friday**:
+
+- 00:00–10:00: Hibernated (replaced schedule's overnight window)
+- 10:00–17:00: Awake (replaced schedule's active window; leadTime prevents hibernate after 17:00)
+- 17:00–22:00: Awake (leadTime buffer + suspend carve-out)
+- 22:00–06:00: Hibernated (replaced schedule resumes)
+
+### Non-Colliding Same-Type: Independent Extend Windows
+
+**Situation**: Two separate events need extra hibernation on different days.
+
+```yaml
+# Team A: extend for Monday training day
+apiVersion: hibernator.ardikabs.com/v1alpha1
+kind: ScheduleException
+metadata:
+  name: monday-training
+  namespace: hibernator-system
+spec:
+  planRef:
+    name: dev-plan
+  type: extend
+  validFrom: "2026-03-02T00:00:00Z"
+  validUntil: "2026-03-02T23:59:59Z"
+  windows:
+    - start: "06:00"
+      end: "20:00"
+      daysOfWeek: ["MON"]
+```
+
+```yaml
+# Team B: extend for Friday offsite
+apiVersion: hibernator.ardikabs.com/v1alpha1
+kind: ScheduleException
+metadata:
+  name: friday-offsite
+  namespace: hibernator-system
+spec:
+  planRef:
+    name: dev-plan
+  type: extend
+  validFrom: "2026-03-06T00:00:00Z"
+  validUntil: "2026-03-06T23:59:59Z"
+  windows:
+    - start: "06:00"
+      end: "20:00"
+      daysOfWeek: ["FRI"]
+```
+
+These are accepted because their windows don't collide (different days). The controller merges both during evaluation.
+
+## Validation Errors
+
+The webhook rejects invalid combinations at admission time. Common rejection messages:
+
+| Scenario | Error |
+|----------|-------|
+| Two extend exceptions with overlapping windows | `same-type exceptions with colliding windows are not allowed; merge into a single exception` |
+| Two replace exceptions with overlapping windows | `same-type exceptions with colliding windows are not allowed; only one replace can be active for a given time range` |
+| Two suspend exceptions with overlapping windows | `same-type exceptions with colliding windows are not allowed; merge into a single exception` |
+
+## Monitoring Composed Exceptions
+
+Check which exceptions are active on a plan:
+
+```bash
+kubectl get scheduleexception -n hibernator-system -l hibernator.ardikabs.com/plan=dev-plan
+```
+
+Check the plan's exception references:
+
+```bash
+kubectl get hibernateplan dev-plan -n hibernator-system \
+  -o jsonpath='{.status.exceptionReferences}' | jq
+```
+
+Up to 10 exception references are tracked, ordered by active state first.
+
+## See Also
+
+- [Concepts: Schedule Exceptions](../concepts/schedule-exceptions.md) — Type definitions, lifecycle states, and composition rules
+- [User Guide: Schedule Exceptions](schedule-exceptions.md) — Creating individual exceptions
+- [Schedule Boundaries](schedule-boundaries.md) — Edge cases in schedule evaluation

--- a/website/docs/user-guides/index.md
+++ b/website/docs/user-guides/index.md
@@ -19,6 +19,7 @@ Step-by-step guides for common Hibernator operations.
 | [Manual Actions](override-actions.md) | Override, restart, and retry operations outside the schedule |
 | [Error Recovery](error-recovery.md) | Handle and recover from execution failures |
 | [Schedule Boundaries](schedule-boundaries.md) | Understand edge cases in schedule evaluation |
+| [Composing Multiple Exceptions](composing-multiple-exceptions.md) | Combine extend, suspend, and replace exceptions on the same plan |
 
 ## Executor Guides
 

--- a/website/docs/user-guides/multi-window-schedules.md
+++ b/website/docs/user-guides/multi-window-schedules.md
@@ -74,16 +74,12 @@ spec:
           instanceIds: ["staging-db"]
 ```
 
-## Edge Cases
+## Adjacent Windows
 
-### Overnight Windows
+If a wakeup time from one window coincides with the start of another window on the same or next listed day, the controller handles this correctly — the system remains hibernated without an unnecessary wakeup/re-hibernate cycle. This is demonstrated in the three-window example above, where the Friday 17:00 window, weekend windows, and Monday 07:00 wakeup form a continuous hibernation period from Friday afternoon through Monday morning.
 
-When `end` is earlier than `start` (e.g., `start: "20:00"`, `end: "06:00"`), the window spans midnight into the next day.
-
-### Adjacent Windows
-
-If a wakeup time from one window coincides with the start of another window, the controller handles this correctly — the system remains hibernated without an unnecessary wakeup/re-hibernate cycle.
-
-### Window Collisions with Exceptions
+## Window Interactions with Exceptions
 
 When a `ScheduleException` of type `extend` adds windows, the new windows are merged with the base schedule using the same OR-logic. If an extend window contains a base wakeup time, the collision is resolved correctly.
+
+For combining multiple exceptions on the same plan (e.g., extend + suspend, replace + extend), see [Composing Multiple Exceptions](composing-multiple-exceptions.md).

--- a/website/docs/user-guides/schedule-boundaries.md
+++ b/website/docs/user-guides/schedule-boundaries.md
@@ -2,6 +2,14 @@
 
 This guide covers edge cases and boundary conditions in schedule evaluation.
 
+## The `daysOfWeek` Execution Boundary
+
+**All executions — both hibernation and wakeup — are bounded to `daysOfWeek`.** A day not listed in `daysOfWeek` is never a subject of execution. This means:
+
+- Hibernation only **starts** on days listed in `daysOfWeek`
+- Wakeup only **triggers** on days listed in `daysOfWeek`
+- If a hibernation period would naturally end on a day **not** in `daysOfWeek`, resources remain hibernated until the next listed day
+
 ## Overnight Windows
 
 When `end` is earlier than `start`, the window spans midnight:
@@ -9,21 +17,36 @@ When `end` is earlier than `start`, the window spans midnight:
 ```yaml
 offHours:
   - start: "20:00"   # 8 PM today
-    end: "06:00"     # 6 AM tomorrow
+    end: "06:00"     # 6 AM next eligible day
     daysOfWeek: ["MON", "TUE", "WED", "THU", "FRI"]
 ```
 
-- Monday 20:00 → Tuesday 06:00
-- Tuesday 20:00 → Wednesday 06:00
-- Friday 20:00 → Saturday 06:00
-
-The `daysOfWeek` refers to the day when the window **starts**.
+- Monday 20:00 → Tuesday 06:00 (Tuesday is in `daysOfWeek`, wakeup proceeds)
+- Tuesday 20:00 → Wednesday 06:00 (Wednesday is in `daysOfWeek`, wakeup proceeds)
+- Thursday 20:00 → Friday 06:00 (Friday is in `daysOfWeek`, wakeup proceeds)
+- **Friday 20:00 → Monday 06:00** (Saturday is **not** in `daysOfWeek`, so wakeup does not trigger Saturday; resources stay hibernated through the weekend until Monday — the next listed day)
 
 ## Day Boundaries
 
-### Friday Night into Saturday
+### Friday Night with Weekday-Only Schedule
 
-A Friday window of `start: "20:00"` / `end: "06:00"` extends into Saturday morning. If you also have a weekend window starting at `00:00` Saturday, Hibernator handles the overlap — resources stay hibernated without unnecessary wakeup/re-hibernate transitions.
+With `daysOfWeek: ["MON", "TUE", "WED", "THU", "FRI"]` and `start: "20:00"` / `end: "06:00"`, Friday's hibernation at 20:00 does **not** wake up Saturday at 06:00. Saturday is not in `daysOfWeek`, so it is not an execution day. Resources remain hibernated through the entire weekend, and wakeup occurs at **Monday 06:00**.
+
+To cover weekends explicitly with separate behavior (e.g., keep resources hibernated all day), add a weekend window:
+
+```yaml
+offHours:
+  # Weeknight window
+  - start: "20:00"
+    end: "06:00"
+    daysOfWeek: ["MON", "TUE", "WED", "THU", "FRI"]
+  # Full weekend
+  - start: "00:00"
+    end: "23:59"
+    daysOfWeek: ["SAT", "SUN"]
+```
+
+With this configuration, the weekend window explicitly governs Saturday and Sunday execution. Without the weekend window, the weekday-only schedule simply keeps resources hibernated from Friday 20:00 through Monday 06:00.
 
 ### Same-Day Windows
 
@@ -53,16 +76,68 @@ schedule:
 Windows near midnight require care:
 
 ```yaml
-# This window runs from 23:30 to 00:30 the next day
+# This window starts Monday 23:30 and ends at 00:30 on the next listed day
 offHours:
   - start: "23:30"
     end: "00:30"
-    daysOfWeek: ["MON"]    # Monday 23:30 → Tuesday 00:30
+    daysOfWeek: ["MON", "TUE"]    # Monday 23:30 → Tuesday 00:30
 ```
 
-## Schedule Evaluation Frequency
+!!! warning
+    If only `["MON"]` were listed, the 00:30 wakeup would not trigger on Tuesday (since Tuesday is not listed). The resources would remain hibernated from Monday 23:30 all the way until the **next Monday at 00:30** — a full week later. Ensure that both the hibernation start day **and** the expected wakeup day are included in `daysOfWeek`.
 
-The controller evaluates schedules on each reconciliation loop. The reconciliation period determines the maximum delay between the scheduled time and the actual action.
+## Execution Timing: Schedule Buffer and Safety Buffer
+
+The controller intentionally delays every execution past the scheduled time by applying two buffers:
+
+| Buffer | Default | Configurable | Purpose |
+|--------|---------|--------------|--------|
+| **Schedule buffer** | 1 minute | Yes (`--schedule-buffer-duration`) | Ensures the controller evaluates *after* the schedule boundary has passed |
+| **Safety buffer** | 10 seconds | No (hardcoded) | Additional guard against clock-skew and race conditions |
+
+**Total offset: up to 1m 10s** after the nominal schedule time (with default settings).
+
+This means a `start: "20:00"` hibernation actually executes around 20:01:10, and an `end: "06:00"` wakeup executes around 06:01:10.
+
+### Why This Exists
+
+The schedule buffer solves the narrow gap in **full-day windows**:
+
+```yaml
+# Full-day shutdown — resources hibernate all day
+offHours:
+  - start: "00:00"
+    end: "23:59"
+    daysOfWeek: ["SAT", "SUN"]
+```
+
+The gap between `23:59:00` and `00:00:00` is only 60 seconds. Without the buffer, the controller could evaluate at exactly `00:00:00` and race against the boundary. The 1-minute schedule buffer pushes evaluation to `00:01:00` (plus 10s safety buffer), well past the `00:00` start time.
+
+The same applies to full-day wakeup windows:
+
+```yaml
+# Full-day wakeup — resources stay awake all day
+offHours:
+  - start: "23:59"
+    end: "00:00"
+    daysOfWeek: ["MON", "TUE", "WED", "THU", "FRI"]
+```
+
+Here the gap between `00:00:00` (end/wakeup) and `23:59:00` (start/hibernate) is even narrower in the other direction. The buffer ensures the wakeup at `00:00` executes cleanly at `00:01:10`.
+
+### Adjusting the Schedule Buffer
+
+The schedule buffer is configurable on the controller:
+
+```bash
+# Increase to 2 minutes (e.g., for slow API environments)
+--schedule-buffer-duration="2m"
+
+# Or via environment variable
+SCHEDULE_BUFFER_DURATION=2m
+```
+
+The safety buffer (10s) is not configurable.
 
 !!! note
     If the controller restarts during a schedule window, it re-evaluates on startup and takes the appropriate action based on the current time and plan state.
@@ -75,4 +150,4 @@ When schedule exceptions are active, they modify the effective schedule:
 - **Suspend**: Specified windows are carved out of the effective schedule
 - **Replace**: Base schedule is completely ignored; only exception windows apply
 
-These modifications affect all boundary calculations. For example, a `suspend` exception that covers a Friday night window prevents the overnight hibernation even though the base schedule includes it.
+These modifications affect all boundary calculations, including the `daysOfWeek` execution boundary. For example, a `suspend` exception that covers a Friday night window prevents the overnight hibernation even though the base schedule includes it. An `extend` exception that adds `SAT` to `daysOfWeek` would cause a Saturday 06:00 wakeup that would otherwise not occur.

--- a/website/docs/user-guides/schedule-exceptions.md
+++ b/website/docs/user-guides/schedule-exceptions.md
@@ -2,62 +2,66 @@
 
 This guide covers creating and managing temporary schedule overrides using `ScheduleException` resources.
 
-## Extending Hibernation for a Weekend
+## Extending Hibernation for a Weekday Holiday
 
-Add hibernation windows during a period when the team won't be working:
+If your base schedule already covers weekday nights (e.g., `start: "20:00"`, `end: "06:00"`, `daysOfWeek: ["MON", "TUE", "WED", "THU", "FRI"]`), weekends are **already fully hibernated** — wakeup only triggers on listed days. So there's no need to extend for weekends.
+
+A practical use of `extend` is covering a **weekday holiday**. Suppose Wednesday is a public holiday and there's no reason to wake up resources in the morning. The base schedule would wake resources at 06:00 on Wednesday, but you want them to stay hibernated all day. Add an extend exception to cover the daytime gap:
 
 ```yaml
 apiVersion: hibernator.ardikabs.com/v1alpha1
 kind: ScheduleException
 metadata:
-  name: conference-weekend
+  name: wednesday-holiday
   namespace: hibernator-system
 spec:
   planRef:
     name: dev-plan
   type: extend
-  validFrom: "2026-02-10T00:00:00Z"
-  validUntil: "2026-02-15T23:59:59Z"
+  validFrom: "2026-02-11T00:00:00Z"
+  validUntil: "2026-02-11T23:59:59Z"
   windows:
-    - start: "00:00"
-      end: "23:59"
-      daysOfWeek: ["SAT", "SUN"]
+    - start: "06:00"
+      end: "20:00"
+      daysOfWeek: ["WED"]
 ```
 
 ```bash
 kubectl apply -f exception.yaml
 ```
 
-The exception adds weekend all-day hibernation on top of the plan's existing weekday schedule.
+This fills the 06:00–20:00 gap on Wednesday, creating continuous hibernation from Tuesday 20:00 through Wednesday 20:00 (when the normal nightly cycle begins again). The base schedule handles the rest — no need to modify it.
 
-## Suspending Hibernation for Maintenance
+## Suspending Hibernation for Cross-Timezone Work
 
-Keep resources awake during a scheduled maintenance window:
+When a team in a different timezone needs resources to stay alive beyond the normal hibernation start time, use a `suspend` exception to hold off hibernation.
+
+**Scenario**: Your base schedule hibernates weekday resources in `Asia/Jakarta` from 20:00 to 06:00. A team in Japan (UTC+9, 2 hours ahead) needs to debug an issue on Wednesday evening and expects resources to stay up past the Jakarta 20:00 cutoff until end of day:
 
 ```yaml
 apiVersion: hibernator.ardikabs.com/v1alpha1
 kind: ScheduleException
 metadata:
-  name: maintenance-window
+  name: japan-team-debug
   namespace: hibernator-system
 spec:
   planRef:
-    name: prod-plan
+    name: dev-plan
   type: suspend
-  validFrom: "2026-02-01T20:00:00Z"
-  validUntil: "2026-02-02T02:00:00Z"
+  validFrom: "2026-02-11T00:00:00Z"
+  validUntil: "2026-02-11T23:59:59Z"
   leadTime: "1h"
   windows:
-    - start: "21:00"
-      end: "02:00"
-      daysOfWeek: ["SAT"]
+    - start: "20:00"
+      end: "23:59"
+      daysOfWeek: ["WED"]
 ```
 
-The `leadTime: "1h"` prevents the controller from starting a new hibernate cycle within 1 hour before the suspension window begins.
+The `leadTime: "1h"` prevents the controller from starting a new hibernate cycle within 1 hour before the suspension window begins (i.e., no hibernation from 19:00 onward on Wednesday). Resources stay awake until 23:59 on Wednesday instead of going down at 20:00.
 
 ## Emergency Incident Override
 
-Immediately prevent hibernation during an active incident:
+To keep resources awake during an active incident that may span the full day:
 
 ```yaml
 apiVersion: hibernator.ardikabs.com/v1alpha1
@@ -110,8 +114,8 @@ During the holiday week, the base schedule is ignored and replaced by the except
 ```bash
 kubectl get scheduleexception -n hibernator-system
 # NAME                  PLAN       TYPE      STATE    VALIDFROM                  VALIDUNTIL                 AGE
-# conference-weekend    dev-plan   extend    Active   2026-02-10T00:00:00Z       2026-02-15T23:59:59Z       2d
-# maintenance-window    prod-plan  suspend   Pending  2026-02-01T20:00:00Z       2026-02-02T02:00:00Z       1h
+# wednesday-holiday     dev-plan   extend    Active   2026-02-11T00:00:00Z       2026-02-11T23:59:59Z       2d
+# japan-team-debug      dev-plan   suspend   Pending  2026-02-11T00:00:00Z       2026-02-11T23:59:59Z       1h
 ```
 
 ### Check Plan Exception History
@@ -125,25 +129,14 @@ Up to 10 exception references are tracked, ordered by active state first, then m
 
 ## Composing Exceptions
 
-You can apply compatible exceptions to the same plan simultaneously:
+You can apply compatible exceptions to the same plan simultaneously. For example, an `extend` and `suspend` exception can coexist — the controller merges them using `mergeByType` semantics.
 
-```bash
-# Add weekend hibernation (extend)
-kubectl apply -f weekend-extension.yaml
-
-# Keep Friday evening awake for release (suspend)
-kubectl apply -f friday-release-window.yaml
-```
-
-An `extend` and `suspend` exception can coexist on the same plan. The controller merges them using `mergeByType` semantics.
-
-!!! warning
-    A `replace` exception cannot coexist with other active exceptions. It overrides everything.
+For detailed scenarios covering all type combinations (extend + suspend, replace + extend, replace + suspend) and validation rules, see [Composing Multiple Exceptions](composing-multiple-exceptions.md).
 
 ## Cleaning Up
 
 Exceptions expire automatically based on `validUntil`. You can delete them early:
 
 ```bash
-kubectl delete scheduleexception conference-weekend -n hibernator-system
+kubectl delete scheduleexception wednesday-holiday -n hibernator-system
 ```

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -70,13 +70,14 @@ nav:
       - Core Operations:
         - Hibernation Lifecycle: user-guides/hibernation-lifecycle.md
         - Execution Strategies: user-guides/execution-strategies.md
-        - Schedule Exceptions: user-guides/schedule-exceptions.md
         - Multi-Window Schedules: user-guides/multi-window-schedules.md
+        - Schedule Exceptions: user-guides/schedule-exceptions.md
       - Operational Guides:
         - Plan Suspension: user-guides/plan-suspension.md
         - Override Actions: user-guides/override-actions.md
         - Error Recovery: user-guides/error-recovery.md
         - Schedule Boundaries: user-guides/schedule-boundaries.md
+        - Composing Multiple Exceptions: user-guides/composing-multiple-exceptions.md
       - Executor Guides:
         - EC2 Executor: user-guides/ec2-executor.md
         - WorkloadScaler Executor: user-guides/workloadscaler-executor.md


### PR DESCRIPTION
- Add new operational guide: Composing Multiple Exceptions
  - Covers extend+suspend, replace+extend, replace+suspend scenarios
  - Compatibility rules, composition order, validation errors
  - Monitoring and cleanup examples

- Document schedule buffer and safety buffer execution timing
  - Controllers delay execution by up to 1m10s by default
  - Solves the 23:59:00 - 00:00:00 gap in full-day windows
  - Configurable via --schedule-buffer-duration flag

- Reorganize schedule exception docs
  - Simplify multi-window-schedules.md (remove overnight windows as normal case)
  - Link from concepts/schedule-exceptions to new composing guide
  - Update user-guides index and nav