### PR TITLE
feat: sink slack with json format for blocks support

### DIFF
--- a/docs/proposals/0006-notification-system.md
+++ b/docs/proposals/0006-notification-system.md
@@ -3,7 +3,7 @@ rfc: RFC-0006
 title: Notification System via HibernateNotification CRD
 status: In Progress 🚀
 date: 2026-02-16
-last-updated: 2026-03-28
+last-updated: 2026-04-13
 ---
 
 # RFC 0006 — Notification System via HibernateNotification CRD
@@ -15,6 +15,8 @@ last-updated: 2026-03-28
 ## Summary
 
 This RFC proposes a decoupled, selector-based notification system for the Hibernator Operator. By introducing a new Custom Resource Definition (CRD) called `HibernateNotification`, users can define notification rules (triggers and sinks) that apply to one or multiple `HibernatePlan` resources based on label selectors. Notifications are delivered through a dedicated lifecycle that integrates with the async phase-driven reconciler via `PlanContext`, using pre/post hooks on status transitions to fire events. Users can customize message formatting through Go templates referenced from ConfigMaps.
+
+For Slack-specific formatting modes (`format=text|json`), template behavior per mode, and preset JSON layouts (`default|compact|progress`), see [RFC-0009](./0009-slack-block-kit-notification-format.md).
 
 ## Motivation
 

--- a/docs/proposals/0009-slack-block-kit-notification-format.md
+++ b/docs/proposals/0009-slack-block-kit-notification-format.md
@@ -1,0 +1,270 @@
+---
+rfc: RFC-0009
+title: Slack Notification Formatting Modes (Text and JSON)
+status: Proposed
+date: 2026-04-13
+last-updated: 2026-04-13
+---
+
+# RFC 0009 - Slack Notification Formatting Modes (Text and JSON)
+
+**Keywords:** Notifications, Slack, Blocks, Templates, Simplicity, Backward-Compatibility
+
+## Summary
+
+This RFC proposes a simplified Slack formatting model for `HibernateNotification` sinks:
+
+- One main mode selector: `format`.
+- Two values only: `text` and `json`.
+- One preset selector for JSON mode: `block_layout`.
+
+The key behavior is:
+
+1. `format=text`: template is interpreted as text.
+2. `format=json`: if template exists, template output is interpreted as JSON blocks payload.
+3. `format=json` without template: use built-in block preset selected by `block_layout`.
+
+This replaces the more complex matrix (`blocks` vs `hybrid`, plus separate `template_mode`) with a simpler operator mental model.
+
+## Motivation
+
+The previous draft introduced too many knobs (`format`, `template_mode`, `layout`, `hybrid`) and created confusion about expected behavior.
+
+Additionally, incoming webhook fields like `channel`, `username`, and `icon_emoji` may not be reliably honored by Slack workspace/app settings, which can make behavior surprising.
+
+This RFC narrows the surface area to predictable controls.
+
+## Goals
+
+- Keep configuration understandable in one read.
+- Keep existing text behavior as default.
+- Support rich Slack Block Kit output when needed.
+- Keep `templateRef` useful in both modes without extra mode flags.
+- Avoid optional fields that may be ignored by Slack incoming webhooks.
+
+## Non-Goals
+
+- No CRD changes.
+- No interactive Slack actions in this phase.
+- No delivery guarantee changes.
+
+## Final Configuration Model
+
+Slack sink config in Secret `config` JSON:
+
+```json
+{
+  "webhook_url": "https://hooks.slack.com/services/T00/B00/XXX",
+  "format": "text",
+  "block_layout": "default",
+  "max_targets": 8
+}
+```
+
+| Field | Type | Required | Default | Description |
+|---|---|---:|---|---|
+| `webhook_url` | string | Yes | - | Slack incoming webhook URL. |
+| `format` | string | No | `text` | `text` or `json`. |
+| `block_layout` | string | No | `default` | Preset used only when `format=json` and no template is provided (or JSON template parsing fails). |
+| `max_targets` | int | No | `8` | Maximum target lines emitted by preset JSON layouts for multi-target events. |
+
+## Field Clarifications
+
+### `max_targets`
+
+`max_targets` only affects built-in JSON preset layouts where a list of targets may be rendered.
+
+- Applies mainly to events carrying `.Targets` (e.g., `Success`, `Failure`).
+- Does not affect `ExecutionProgress` when only `.TargetExecution` is shown.
+- Helps avoid oversized/noisy Slack payloads.
+
+### `channel`, `username`, `icon_emoji` (intentionally omitted)
+
+These are intentionally omitted from v1 proposal for clarity and predictability.
+
+Reason:
+
+- Slack incoming webhooks are often bound to app/channel defaults.
+- Overrides may be ignored depending on Slack app/workspace policy.
+- Including them as first-class fields can imply guarantees we cannot provide.
+
+If needed later, they can be added back as optional best-effort fields with explicit caveats.
+
+## Rendering Behavior
+
+### `format=text`
+
+- If `templateRef` exists: render template as text and send as Slack `text` message.
+- If `templateRef` is missing: use built-in default text template.
+- No Slack blocks are attached.
+
+### `format=json`
+
+- If `templateRef` exists: render template and treat output as JSON payload.
+  - Expected shape:
+    - object containing at least `blocks`, and optionally `text`.
+  - If parsing or validation fails: fallback to preset builder using `block_layout`.
+- If `templateRef` is missing: use preset builder using `block_layout`.
+
+Implementation note: include fallback `text` whenever possible for compatibility and accessibility.
+
+## Preset Layouts (`block_layout`)
+
+Proposed values:
+
+- `default`: balanced summary + detail layout.
+- `compact`: short high-signal layout for noisy channels.
+- `progress`: special layout optimized for `ExecutionProgress` events.
+
+Why `progress` is clearer:
+
+- The intent is event-centric (`ExecutionProgress`), not data-shape-centric.
+- Easier to understand for operators reading sink config.
+
+### Event behavior for `progress`
+
+- For `ExecutionProgress`: highlight `.TargetExecution` as primary content.
+- For non-`ExecutionProgress` events: fallback to `default` layout behavior.
+
+## Template Forms by `format`
+
+### A) `format=text` template example
+
+```gotpl
+{{- if eq .Event "Failure" -}}
+:rotating_light: *Hibernation Failed*
+{{- else if eq .Event "Success" -}}
+:white_check_mark: *Hibernation Completed*
+{{- else -}}
+:information_source: *{{ .Event }}*
+{{- end }}
+*Plan:* {{ .Plan.Namespace }}/{{ .Plan.Name }}
+*Phase:* {{ .Phase }}
+{{- if .ErrorMessage }}
+*Error:* {{ .ErrorMessage }}
+{{- end }}
+```
+
+### B) `format=json` template example
+
+```gotpl
+{{- $fallback := printf "[%s] %s/%s phase=%s" .Event .Plan.Namespace .Plan.Name .Phase -}}
+{
+  "text": {{ $fallback | toJson }},
+  "blocks": [
+    {
+      "type": "header",
+      "text": { "type": "plain_text", "text": "Hibernator Notification" }
+    },
+    {
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": {{ (printf "*Event:* %s\\n*Plan:* `%s/%s`\\n*Phase:* `%s`" .Event .Plan.Namespace .Plan.Name .Phase) | toJson }}
+      }
+    }
+  ]
+}
+```
+
+## Sample Outputs
+
+Given event:
+
+```json
+{
+  "event": "Failure",
+  "operation": "shutdown",
+  "phase": "Error",
+  "retryCount": 3,
+  "errorMessage": "RDS stop timed out after 300s",
+  "plan": { "namespace": "prod", "name": "payroll-nightly" },
+  "targets": [
+    { "name": "rds-main", "executor": "rds", "state": "Failed" },
+    { "name": "eks-app", "executor": "eks", "state": "Completed" }
+  ]
+}
+```
+
+### `format=text`
+
+```text
+:rotating_light: Hibernation Failed
+Plan: prod/payroll-nightly
+Phase: Error
+Error: RDS stop timed out after 300s
+```
+
+### `format=json` + `block_layout=default`
+
+```text
+[Header] Hibernation Failed
+[Section] Plan: prod/payroll-nightly | Phase: Error | Operation: shutdown
+[Section] Error: RDS stop timed out after 300s
+[Section] Targets (up to max_targets)
+[Context] Retry: 3
+```
+
+### `format=json` + `block_layout=progress` (for `ExecutionProgress`)
+
+```text
+[Header] Execution Progress
+[Section] Target: rds-main (rds)
+[Section] State: Running
+[Context] Plan: prod/payroll-nightly | Cycle: abc123
+```
+
+## Prototype Flow
+
+```go
+rendered := s.renderer.Render(ctx, payload, renderOpts...)
+
+switch cfg.Format {
+case "text":
+    msg := &slackapi.WebhookMessage{Text: rendered}
+    return post(msg)
+
+case "json":
+    // If template provided, try parse rendered as JSON payload first.
+    if hasCustomTemplate {
+        if msg, ok := parseJSONWebhookMessage(rendered); ok {
+            return post(msg)
+        }
+    }
+
+    // Fallback: preset builder from block_layout.
+    msg := buildPresetJSONMessage(payload, cfg.BlockLayout, cfg.MaxTargets)
+    return post(msg)
+
+default:
+    // defensive fallback
+    msg := &slackapi.WebhookMessage{Text: rendered}
+    return post(msg)
+}
+```
+
+## Backward Compatibility
+
+- Existing secrets with only `webhook_url` continue to work (`format=text` by default).
+- Existing text templates continue to work unchanged.
+- JSON mode is opt-in and safe by fallback-to-preset on invalid JSON template output.
+
+## Implementation Plan
+
+1. Extend Slack config parser with `format`, `block_layout`, `max_targets`.
+2. Implement preset builders: `default`, `compact`, `progress`.
+3. Implement JSON template parse path for `format=json`.
+4. Add fallback logic and tests.
+5. Update docs and examples.
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Invalid JSON template output | Fallback to preset `block_layout`. |
+| Oversized block payload | Enforce `max_targets`, truncate long detail lines if needed. |
+| Layout confusion across events | Define `progress` as `ExecutionProgress`-optimized with fallback to `default` for other events. |
+
+## References
+
+- Base notification architecture: [RFC-0006](./0006-notification-system.md)

--- a/hack/tools/gen-sink-docs/main.go
+++ b/hack/tools/gen-sink-docs/main.go
@@ -42,7 +42,10 @@ var sinkTypes = []struct {
 	{
 		Dir:         "slack",
 		DisplayName: "Slack",
-		Description: "Delivers messages via [Slack Incoming Webhooks](https://api.slack.com/messaging/webhooks).",
+		Description: "Delivers messages via [Slack Incoming Webhooks](https://api.slack.com/messaging/webhooks).\n\n" +
+			"!!! tip \"Formatting Message Text (Slack)\"\n" +
+			"    When `format: json` is configured, message content is rendered using Slack message formatting semantics (`mrkdwn`/`plain_text`).\n" +
+			"    See Slack docs: [Formatting message text](https://docs.slack.dev/messaging/formatting-message-text/).",
 	},
 	{
 		Dir:         "telegram",

--- a/internal/notification/dispatcher_test.go
+++ b/internal/notification/dispatcher_test.go
@@ -7,9 +7,13 @@ package notification
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"sync"
 	"sync/atomic"
@@ -26,6 +30,7 @@ import (
 
 	hibernatorv1alpha1 "github.com/ardikabs/hibernator/api/v1alpha1"
 	sinktypes "github.com/ardikabs/hibernator/internal/notification/sink"
+	slacksink "github.com/ardikabs/hibernator/internal/notification/sink/slack"
 )
 
 // stubSink is a test double that records Send calls.
@@ -551,6 +556,148 @@ func TestDispatcher_MalformedCustomTemplate(t *testing.T) {
 
 	require.True(t, stub.waitCalls(1, 2*time.Second))
 	assert.Equal(t, "Start", stub.getCalls()[0].Payload.Event)
+}
+
+func TestDispatcher_SlackJSONTemplate_EndToEnd(t *testing.T) {
+	receivedCh := make(chan map[string]any, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+
+		var payload map[string]any
+		require.NoError(t, json.Unmarshal(body, &payload))
+		select {
+		case receivedCh <- payload:
+		default:
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok")) //nolint:errcheck
+	}))
+	defer server.Close()
+
+	secret := sinkSecret("default", "slack-secret", []byte(fmt.Sprintf(`{"webhook_url":%q,"format":"json"}`, server.URL)))
+	tmplKey := defaultTemplateKey
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "slack-json-template"},
+		Data: map[string]string{
+			tmplKey: `{
+	"text": {{ (printf "custom %s %s/%s" .Event .Plan.Namespace .Plan.Name) | toJson }},
+	"blocks": [
+		{
+			"type": "section",
+			"text": {"type": "mrkdwn", "text": {{ (printf "*Plan:* %s/%s" .Plan.Namespace .Plan.Name) | toJson }}}
+		}
+	]
+}`,
+		},
+	}
+
+	client := fake.NewClientBuilder().
+		WithScheme(newTestScheme()).
+		WithObjects(secret, cm).
+		Build()
+
+	registry := sinktypes.NewRegistry()
+	registry.Register(slacksink.New(NewTemplateEngine(logr.Discard()), slacksink.WithHTTPClient(&http.Client{Timeout: 5 * time.Second})))
+
+	d := NewDispatcher(logr.Discard(), client, registry, DispatcherConfig{Workers: 1, ChannelSize: 8})
+	startDispatcher(t, d)
+
+	d.Submit(Request{
+		Payload:   testPayload("Start"),
+		SinkName:  "slack-json",
+		SinkType:  "slack",
+		SecretRef: hibernatorv1alpha1.ObjectKeyReference{Name: "slack-secret"},
+		TemplateRef: &hibernatorv1alpha1.ObjectKeyReference{
+			Name: "slack-json-template",
+			Key:  &tmplKey,
+		},
+	})
+
+	select {
+	case got := <-receivedCh:
+		text, _ := got["text"].(string)
+		assert.Contains(t, text, "custom Start default/test-plan")
+
+		blocks, ok := got["blocks"].([]any)
+		require.True(t, ok)
+		require.NotEmpty(t, blocks)
+
+		first, ok := blocks[0].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "section", first["type"])
+
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for Slack webhook payload")
+	}
+}
+
+func TestDispatcher_SlackJSONTemplate_InvalidFallsBackToPreset(t *testing.T) {
+	receivedCh := make(chan map[string]any, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+
+		var payload map[string]any
+		require.NoError(t, json.Unmarshal(body, &payload))
+		select {
+		case receivedCh <- payload:
+		default:
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok")) //nolint:errcheck
+	}))
+	defer server.Close()
+
+	secret := sinkSecret("default", "slack-secret", []byte(fmt.Sprintf(`{"webhook_url":%q,"format":"json","block_layout":"compact"}`, server.URL)))
+	tmplKey := defaultTemplateKey
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "slack-bad-json-template"},
+		Data: map[string]string{
+			tmplKey: `this is not json`,
+		},
+	}
+
+	client := fake.NewClientBuilder().
+		WithScheme(newTestScheme()).
+		WithObjects(secret, cm).
+		Build()
+
+	registry := sinktypes.NewRegistry()
+	registry.Register(slacksink.New(NewTemplateEngine(logr.Discard()), slacksink.WithHTTPClient(&http.Client{Timeout: 5 * time.Second})))
+
+	d := NewDispatcher(logr.Discard(), client, registry, DispatcherConfig{Workers: 1, ChannelSize: 8})
+	startDispatcher(t, d)
+
+	d.Submit(Request{
+		Payload:   testPayload("Start"),
+		SinkName:  "slack-json",
+		SinkType:  "slack",
+		SecretRef: hibernatorv1alpha1.ObjectKeyReference{Name: "slack-secret"},
+		TemplateRef: &hibernatorv1alpha1.ObjectKeyReference{
+			Name: "slack-bad-json-template",
+			Key:  &tmplKey,
+		},
+	})
+
+	select {
+	case got := <-receivedCh:
+		text, _ := got["text"].(string)
+		assert.Contains(t, text, "[Start]")
+		assert.Contains(t, text, "default/test-plan")
+
+		blocks, ok := got["blocks"].([]any)
+		require.True(t, ok)
+		require.NotEmpty(t, blocks)
+
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for Slack webhook payload")
+	}
 }
 
 func TestDispatcher_SubmitAfterShutdown(t *testing.T) {

--- a/internal/notification/sink/slack/blocks.go
+++ b/internal/notification/sink/slack/blocks.go
@@ -1,0 +1,391 @@
+/*
+Copyright 2026 Ardika Saputro.
+Licensed under the Apache License, Version 2.0.
+*/
+
+package slack
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	slackapi "github.com/slack-go/slack"
+
+	hibernatorv1alpha1 "github.com/ardikabs/hibernator/api/v1alpha1"
+	"github.com/ardikabs/hibernator/internal/notification/sink"
+)
+
+func presetJSONMessage(payload sink.Payload, layout string, maxTargets int, additionalScopes []string) *slackapi.WebhookMessage {
+	factory := newLayoutFactory()
+	composer := newLayoutComposer(payload, maxTargets, additionalScopes)
+	return &slackapi.WebhookMessage{
+		Text:   fallbackText(payload),
+		Blocks: &slackapi.Blocks{BlockSet: factory.build(layout, composer)},
+	}
+}
+
+type layoutFactory struct {
+	builders map[string]func(*layoutComposer) []slackapi.Block
+}
+
+func newLayoutFactory() *layoutFactory {
+	return &layoutFactory{
+		builders: map[string]func(*layoutComposer) []slackapi.Block{
+			blockLayoutDefault:  (*layoutComposer).buildDefault,
+			blockLayoutCompact:  (*layoutComposer).buildCompact,
+			blockLayoutProgress: (*layoutComposer).buildProgress,
+		},
+	}
+}
+
+func (f *layoutFactory) build(layout string, composer *layoutComposer) []slackapi.Block {
+	resolved := layout
+	if resolved == blockLayoutProgress && composer.payload.Event != "ExecutionProgress" {
+		resolved = blockLayoutDefault
+	}
+
+	builder, ok := f.builders[resolved]
+	if !ok {
+		builder = f.builders[blockLayoutDefault]
+	}
+	return builder(composer)
+}
+
+type layoutComposer struct {
+	payload          sink.Payload
+	maxTargets       int
+	additionalScopes []string
+}
+
+func newLayoutComposer(payload sink.Payload, maxTargets int, additionalScopes []string) *layoutComposer {
+	return &layoutComposer{
+		payload:          payload,
+		maxTargets:       maxTargets,
+		additionalScopes: additionalScopes,
+	}
+}
+
+func (c *layoutComposer) buildDefault() []slackapi.Block {
+	scope := c.scopeLine()
+	hasScope := scope != ""
+	errorMessage := c.payload.ErrorMessage
+	hasError := errorMessage != ""
+
+	return newBlockSetBuilder(8).
+		Add(
+			slackapi.NewHeaderBlock(plainText().WithEmoji().WithText(c.headerTitle()).Build()),
+			slackapi.NewDividerBlock(),
+			slackapi.NewSectionBlock(mdText().WithText(c.summaryLine()).Build(), nil, nil),
+		).
+		AddWhen(hasError, slackapi.NewSectionBlock(mdText().WithText(fmt.Sprintf("*Error:* %s", errorMessage)).Build(), nil, nil)).
+		AddWhenTextBlocks(targetLines(c.payload.Targets, c.maxTargets), func(targets string) []slackapi.Block {
+			return []slackapi.Block{
+				slackapi.NewDividerBlock(),
+				slackapi.NewSectionBlock(mdText().WithText(targets).Build(), nil, nil),
+			}
+		}).
+		Add(c.metaContextBlock()).
+		AddWhen(hasScope, c.scopeContextBlock(scope)).
+		Build()
+}
+
+func (c *layoutComposer) buildCompact() []slackapi.Block {
+	targets := ""
+	if c.payload.Event != "ExecutionProgress" {
+		targets = targetLines(c.payload.Targets, c.maxTargets)
+	}
+	scope := c.scopeLine()
+	hasScope := scope != ""
+	errorMessage := c.payload.ErrorMessage
+	hasError := errorMessage != ""
+
+	return newBlockSetBuilder(6).
+		Add(slackapi.NewSectionBlock(mdText().WithText(c.compactSummary()).Build(), nil, nil)).
+		AddWhen(hasError, slackapi.NewSectionBlock(mdText().WithText(fmt.Sprintf("*Error:* %s", errorMessage)).Build(), nil, nil)).
+		AddWhenText(targets, func(v string) slackapi.Block {
+			return slackapi.NewSectionBlock(mdText().WithText(v).Build(), nil, nil)
+		}).
+		Add(c.metaContextBlock()).
+		AddWhen(hasScope, c.scopeContextBlock(scope)).
+		Build()
+}
+
+func (c *layoutComposer) buildProgress() []slackapi.Block {
+	target := c.payload.TargetExecution
+	if target == nil {
+		return []slackapi.Block{}
+	}
+
+	sectionText := (*slackapi.TextBlockObject)(nil)
+	if msg := strings.TrimSpace(target.Message); msg != "" {
+		sectionText = mdText().WithText(msg).Build()
+	}
+
+	section := slackapi.NewSectionBlock(
+		sectionText,
+		[]*slackapi.TextBlockObject{
+			mdText().WithText(fmt.Sprintf("*Target:* %s", target.Name)).Build(),
+			mdText().WithText(fmt.Sprintf("*Type:* %s", target.Executor)).Build(),
+			mdText().WithText(fmt.Sprintf("*Operation:* %s", c.payload.Operation)).Build(),
+			mdText().WithText(fmt.Sprintf("*State:* %s", target.State)).Build(),
+		},
+		nil,
+	)
+
+	title := ":loading: Execution Progress"
+	if strings.EqualFold(target.State, "Completed") {
+		title = ":white_check_mark: Execution Completed"
+	}
+	scope := c.scopeLine()
+	hasScope := scope != ""
+	errorMessage := c.payload.ErrorMessage
+	hasError := errorMessage != ""
+
+	return newBlockSetBuilder(7).
+		Add(slackapi.NewHeaderBlock(plainText().WithEmoji().WithText(title).Build())).
+		AddWhen(hasScope, c.scopeContextBlock(scope)).
+		Add(slackapi.NewDividerBlock(), section).
+		AddWhen(hasError, slackapi.NewSectionBlock(mdText().WithText(fmt.Sprintf("*Error:* %s", errorMessage)).Build(), nil, nil)).
+		Add(c.metaContextBlock()).
+		Build()
+}
+
+func (c *layoutComposer) headerTitle() string {
+	switch hibernatorv1alpha1.NotificationEvent(c.payload.Event) {
+	case hibernatorv1alpha1.EventStart:
+		if c.payload.Operation == "shutdown" {
+			return ":arrow_forward: Hibernation Starting"
+		}
+		return ":arrow_forward: Wake-Up Starting"
+	case hibernatorv1alpha1.EventSuccess:
+		if c.payload.Operation == "shutdown" {
+			return ":white_check_mark: Hibernation Completed"
+		}
+		return ":white_check_mark: Wake-Up Completed"
+	case hibernatorv1alpha1.EventFailure:
+		if c.payload.Operation == "shutdown" {
+			return ":alert: Hibernation Failed"
+		}
+		return ":alert: Wake-Up Failed"
+	case hibernatorv1alpha1.EventRecovery:
+		if c.payload.Operation == "shutdown" {
+			return ":repeat: Hibernation Retrying"
+		}
+		return ":repeat: Wake-Up Retrying"
+	default:
+		return ":repeat: Phase Change"
+	}
+}
+
+func (c *layoutComposer) summaryLine() string {
+	plan := fmt.Sprintf("%s/%s", c.payload.Plan.Namespace, c.payload.Plan.Name)
+	parts := []string{
+		fmt.Sprintf("*Plan:* `%s`", plan),
+		fmt.Sprintf("*Phase:* `%s`", c.payload.Phase),
+	}
+	if c.payload.Operation != "" {
+		parts = append(parts, fmt.Sprintf("*Operation:* `%s`", c.payload.Operation))
+	}
+	if c.payload.RetryCount > 0 {
+		parts = append(parts, fmt.Sprintf("*Retry:* `%d`", c.payload.RetryCount))
+	}
+	return strings.Join(parts, "\n")
+}
+
+func (c *layoutComposer) compactSummary() string {
+	return fmt.Sprintf("*%s* | `%s/%s` | `%s`", c.payload.Event, c.payload.Plan.Namespace, c.payload.Plan.Name, c.payload.Phase)
+}
+
+func (c *layoutComposer) contextLine() string {
+	ts := c.payload.Timestamp
+	if ts.IsZero() {
+		ts = time.Now().UTC()
+	}
+	parts := []string{fmt.Sprintf("Event: *%s*", c.payload.Event)}
+	if c.payload.CycleID != "" {
+		parts = append(parts, fmt.Sprintf("Cycle: `%s`", c.payload.CycleID))
+	}
+	parts = append(parts, fmt.Sprintf("Time: %s", ts.UTC().Format(time.RFC3339)))
+	return strings.Join(parts, " • ")
+}
+
+func (c *layoutComposer) metaContextBlock() *slackapi.ContextBlock {
+	return slackapi.NewContextBlock("notification-meta", mdText().WithText(c.contextLine()).Build())
+}
+
+func (c *layoutComposer) scopeContextBlock(scope string) *slackapi.ContextBlock {
+	return slackapi.NewContextBlock("notification-scope", mdText().WithText(scope).Build())
+}
+
+func (c *layoutComposer) scopeLine() string {
+	connector := c.discoverScopeConnector()
+	orderedScopes := make([]string, 0, 2+len(c.additionalScopes))
+	orderedScopes = append(orderedScopes, scopeAccount, scopeCluster)
+	orderedScopes = append(orderedScopes, c.additionalScopes...)
+
+	seen := make(map[string]struct{}, len(orderedScopes))
+	parts := make([]string, 0, len(orderedScopes))
+	for _, rawScope := range orderedScopes {
+		scope := normalizeScope(rawScope)
+		if scope == "" {
+			continue
+		}
+		if _, exists := seen[scope]; exists {
+			continue
+		}
+		seen[scope] = struct{}{}
+
+		part, ok := c.scopePart(scope, connector)
+		if ok {
+			parts = append(parts, part)
+		}
+	}
+
+	return strings.Join(parts, " • ")
+}
+
+func (c *layoutComposer) scopePart(scope string, connector sink.ConnectorInfo) (string, bool) {
+	switch scope {
+	case scopeAccount:
+		if connector.AccountID == "" {
+			return "", false
+		}
+		return fmt.Sprintf("*Account:* `%s`", connector.AccountID), true
+	case scopeCluster:
+		if connector.ClusterName == "" {
+			return "", false
+		}
+		return fmt.Sprintf("*Cluster:* `%s`", connector.ClusterName), true
+	case scopeEnvironment:
+		env := c.discoverEnvironment()
+		if env == "" {
+			return "", false
+		}
+		return fmt.Sprintf("*Environment:* `%s`", env), true
+	case scopeRegion:
+		if connector.Region == "" {
+			return "", false
+		}
+		return fmt.Sprintf("*Region:* `%s`", connector.Region), true
+	case scopeProject:
+		if connector.ProjectID == "" {
+			return "", false
+		}
+		return fmt.Sprintf("*Project:* `%s`", connector.ProjectID), true
+	case scopeProvider:
+		if connector.Provider == "" {
+			return "", false
+		}
+		return fmt.Sprintf("*Provider:* `%s`", connector.Provider), true
+	case scopeConnector:
+		if connector.Name == "" {
+			return "", false
+		}
+		return fmt.Sprintf("*Connector:* `%s`", connector.Name), true
+	default:
+		return "", false
+	}
+}
+
+func (c *layoutComposer) discoverScopeConnector() sink.ConnectorInfo {
+	if c.payload.TargetExecution != nil && hasConnectorScopeData(c.payload.TargetExecution.Connector) {
+		return c.payload.TargetExecution.Connector
+	}
+
+	for _, target := range c.payload.Targets {
+		if strings.EqualFold(target.State, "Failed") && hasConnectorScopeData(target.Connector) {
+			return target.Connector
+		}
+	}
+
+	for _, target := range c.payload.Targets {
+		if hasConnectorScopeData(target.Connector) {
+			return target.Connector
+		}
+	}
+
+	return sink.ConnectorInfo{}
+}
+
+func (c *layoutComposer) discoverEnvironment() string {
+	for _, key := range []string{"env", "environment"} {
+		if v := c.payload.Plan.Labels[key]; strings.TrimSpace(v) != "" {
+			return strings.TrimSpace(v)
+		}
+	}
+	for _, key := range []string{"env", "environment"} {
+		if v := c.payload.Plan.Annotations[key]; strings.TrimSpace(v) != "" {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
+}
+
+func hasConnectorScopeData(connector sink.ConnectorInfo) bool {
+	return connector.AccountID != "" ||
+		connector.ClusterName != "" ||
+		connector.Region != "" ||
+		connector.ProjectID != "" ||
+		connector.Provider != "" ||
+		connector.Name != ""
+}
+func fallbackText(payload sink.Payload) string {
+	parts := []string{
+		fmt.Sprintf("[%s] %s/%s", payload.Event, payload.Plan.Namespace, payload.Plan.Name),
+		fmt.Sprintf("phase=%s", payload.Phase),
+	}
+	if payload.Operation != "" {
+		parts = append(parts, fmt.Sprintf("operation=%s", payload.Operation))
+	}
+	if payload.ErrorMessage != "" {
+		parts = append(parts, fmt.Sprintf("error=%s", payload.ErrorMessage))
+	}
+	return strings.Join(parts, " | ")
+}
+
+func targetLines(targets []sink.TargetInfo, maxTargets int) string {
+	if len(targets) == 0 {
+		return ""
+	}
+	if maxTargets <= 0 {
+		maxTargets = defaultMaxTargets
+	}
+
+	ordered := make([]sink.TargetInfo, len(targets))
+	copy(ordered, targets)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		if ordered[i].State == ordered[j].State {
+			return ordered[i].Name < ordered[j].Name
+		}
+		if ordered[i].State == "Failed" {
+			return true
+		}
+		if ordered[j].State == "Failed" {
+			return false
+		}
+		return ordered[i].Name < ordered[j].Name
+	})
+
+	count := len(ordered)
+	if count > maxTargets {
+		count = maxTargets
+	}
+
+	lines := make([]string, 0, count+1)
+	for i := 0; i < count; i++ {
+		t := ordered[i]
+		line := fmt.Sprintf("- %s (%s) -> `%s`", t.Name, t.Executor, t.State)
+		if t.Message != "" {
+			line += " — " + t.Message
+		}
+		lines = append(lines, line)
+	}
+
+	if len(ordered) > count {
+		lines = append(lines, fmt.Sprintf("... and %d more target(s)", len(ordered)-count))
+	}
+
+	return strings.Join(lines, "\n")
+}

--- a/internal/notification/sink/slack/config.go
+++ b/internal/notification/sink/slack/config.go
@@ -5,8 +5,106 @@ Licensed under the Apache License, Version 2.0.
 
 package slack
 
+import "strings"
+
+const (
+	// formatText sends only plain text content.
+	formatText = "text"
+	// formatJSON sends Slack JSON payloads with blocks.
+	formatJSON = "json"
+
+	// blockLayoutDefault is the balanced summary+detail layout.
+	blockLayoutDefault = "default"
+	// blockLayoutCompact is the short high-signal layout.
+	blockLayoutCompact = "compact"
+	// blockLayoutProgress is optimized for ExecutionProgress events.
+	blockLayoutProgress = "progress"
+
+	// Scope keys for JSON preset footer metadata.
+	scopeAccount     = "account"
+	scopeCluster     = "cluster"
+	scopeEnvironment = "environment"
+	scopeRegion      = "region"
+	scopeProject     = "project"
+	scopeProvider    = "provider"
+	scopeConnector   = "connector"
+
+	defaultFormat      = formatText
+	defaultBlockLayout = blockLayoutDefault
+	defaultMaxTargets  = 8
+)
+
 // config is the expected JSON schema for the Secret's "config" key.
 type config struct {
 	// WebhookURL is the Slack Incoming Webhook URL.
 	WebhookURL string `json:"webhook_url"`
+
+	// Format controls Slack payload mode.
+	// Supported values: `text` (message text only), and
+	// `json` (Slack blocks payload, using preset layouts or custom templates).
+	Format string `json:"format,omitempty"`
+
+	// BlockLayout selects the preset JSON layout used when format=json and
+	// no custom JSON template is provided (or parsing fails).
+	// Supported values: `default`, `compact`, `progress`.
+	BlockLayout string `json:"block_layout,omitempty"`
+
+	// MaxTargets limits target lines in preset JSON layouts.
+	// It defaults to 8, which is enough to show all targets in most cases while keeping the message concise.
+	MaxTargets int `json:"max_targets,omitempty"`
+
+	// AdditionalScopes appends additional scope fields to the scope context.
+	// Account and Cluster are always included by default.
+	// Supported: `environment` (alias: env), `region`, `project`, `provider`, `connector`,
+	// `account`, `cluster`.
+	AdditionalScopes []string `json:"additional_scopes,omitempty"`
+}
+
+func (c *config) useDefaults() {
+	c.Format = strings.ToLower(strings.TrimSpace(c.Format))
+	if c.Format == "" {
+		c.Format = defaultFormat
+	}
+
+	c.BlockLayout = strings.ToLower(strings.TrimSpace(c.BlockLayout))
+	if c.BlockLayout == "" {
+		c.BlockLayout = defaultBlockLayout
+	}
+
+	if c.MaxTargets <= 0 {
+		c.MaxTargets = defaultMaxTargets
+	}
+
+	c.AdditionalScopes = normalizeScopeList(c.AdditionalScopes)
+}
+
+func normalizeScopeList(scopes []string) []string {
+	seen := make(map[string]struct{}, len(scopes))
+	out := make([]string, 0, len(scopes))
+	for _, raw := range scopes {
+		s := normalizeScope(raw)
+		if s == "" {
+			continue
+		}
+		if _, exists := seen[s]; exists {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}
+
+func normalizeScope(scope string) string {
+	s := strings.ToLower(strings.TrimSpace(scope))
+	switch s {
+	case "env":
+		return scopeEnvironment
+	case "account_id", "accountid":
+		return scopeAccount
+	case "cluster_id", "clusterid":
+		return scopeCluster
+	default:
+		return s
+	}
 }

--- a/internal/notification/sink/slack/slack.go
+++ b/internal/notification/sink/slack/slack.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	slackapi "github.com/slack-go/slack"
 
@@ -57,27 +58,110 @@ func (s *Sink) Type() string {
 }
 
 // Send renders the notification payload using the Slack template and delivers it
-// via Incoming Webhook. If opts.CustomTemplateRef is set, that template is used
-// instead of the built-in default.
+// via Incoming Webhook.
+//
+// Behavior by config.format:
+//   - text (default): render text and send as plain Slack text message.
+//   - json: if custom template is provided, render and parse JSON payload;
+//     otherwise build a preset JSON blocks payload.
 func (s *Sink) Send(ctx context.Context, payload sink.Payload, opts sink.SendOptions) error {
 	var cfg config
 	if err := json.Unmarshal(opts.Config, &cfg); err != nil {
 		return fmt.Errorf("parse slack sink config: %w", err)
 	}
+	cfg.useDefaults()
+	if err := cfg.validate(); err != nil {
+		return err
+	}
 	if cfg.WebhookURL == "" {
 		return fmt.Errorf("slack sink config: webhook_url is required")
 	}
 
-	var renderOpts []sink.RenderOption
-	if opts.CustomTemplate != nil {
-		renderOpts = append(renderOpts, sink.WithCustomTemplate(opts.CustomTemplate))
-	}
-
-	content := s.renderer.Render(ctx, payload, renderOpts...)
-	msg := &slackapi.WebhookMessage{Text: content}
+	msg := s.buildMessage(ctx, payload, cfg, opts.CustomTemplate)
 
 	if err := slackapi.PostWebhookCustomHTTPContext(ctx, cfg.WebhookURL, s.client, msg); err != nil {
 		return fmt.Errorf("send slack notification: %w", err)
+	}
+
+	return nil
+}
+
+func (s *Sink) buildMessage(ctx context.Context, payload sink.Payload, cfg config, customTemplate *sink.CustomTemplate) *slackapi.WebhookMessage {
+	switch cfg.Format {
+	case formatJSON:
+		if customTemplate != nil {
+			rendered := s.renderer.Render(ctx, payload, sink.WithCustomTemplate(customTemplate))
+			if msg, err := parseJSONTemplateMessage(rendered, payload); err == nil {
+				return msg
+			}
+		}
+		return presetJSONMessage(payload, cfg.BlockLayout, cfg.MaxTargets, cfg.AdditionalScopes)
+
+	case formatText:
+		fallthrough
+	default:
+		var renderOpts []sink.RenderOption
+		if customTemplate != nil {
+			renderOpts = append(renderOpts, sink.WithCustomTemplate(customTemplate))
+		}
+		content := s.renderer.Render(ctx, payload, renderOpts...)
+		return &slackapi.WebhookMessage{Text: content}
+	}
+}
+
+func parseJSONTemplateMessage(rendered string, payload sink.Payload) (*slackapi.WebhookMessage, error) {
+	rendered = strings.TrimSpace(rendered)
+	if rendered == "" {
+		return nil, fmt.Errorf("empty template output")
+	}
+
+	var msg slackapi.WebhookMessage
+	if err := json.Unmarshal([]byte(rendered), &msg); err == nil {
+		if msg.Blocks != nil && len(msg.Blocks.BlockSet) > 0 {
+			if strings.TrimSpace(msg.Text) == "" {
+				msg.Text = fallbackText(payload)
+			}
+			return &msg, nil
+		}
+	}
+
+	var blocks slackapi.Blocks
+	if err := json.Unmarshal([]byte(rendered), &blocks); err == nil && len(blocks.BlockSet) > 0 {
+		return &slackapi.WebhookMessage{
+			Text:   fallbackText(payload),
+			Blocks: &blocks,
+		}, nil
+	}
+
+	return nil, fmt.Errorf("template output is not a valid Slack JSON payload")
+}
+
+func (c config) validate() error {
+	switch c.Format {
+	case formatText, formatJSON:
+		// ok
+	default:
+		return fmt.Errorf("slack sink config: format must be %q or %q", formatText, formatJSON)
+	}
+
+	if c.Format != formatJSON {
+		return nil
+	}
+
+	switch c.BlockLayout {
+	case blockLayoutDefault, blockLayoutCompact, blockLayoutProgress:
+		// ok
+	default:
+		return fmt.Errorf("slack sink config: block_layout must be one of %q, %q, %q", blockLayoutDefault, blockLayoutCompact, blockLayoutProgress)
+	}
+
+	for _, scope := range c.AdditionalScopes {
+		switch scope {
+		case scopeAccount, scopeCluster, scopeEnvironment, scopeRegion, scopeProject, scopeProvider, scopeConnector:
+			// ok
+		default:
+			return fmt.Errorf("slack sink config: unsupported additional scope %q", scope)
+		}
 	}
 
 	return nil

--- a/internal/notification/sink/slack/slack_test.go
+++ b/internal/notification/sink/slack/slack_test.go
@@ -8,6 +8,7 @@ package slack
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -22,9 +23,18 @@ import (
 )
 
 // stubRenderer implements sink.Renderer for tests.
-type stubRenderer struct{}
+type stubRenderer struct {
+	defaultText string
+}
 
-func (r *stubRenderer) Render(_ context.Context, p sink.Payload, _ ...sink.RenderOption) string {
+func (r *stubRenderer) Render(_ context.Context, p sink.Payload, opts ...sink.RenderOption) string {
+	cfg := sink.NewRenderConfig(opts...)
+	if cfg.CustomTemplate != nil {
+		return cfg.CustomTemplate.Content
+	}
+	if r.defaultText != "" {
+		return r.defaultText
+	}
 	return "rendered:" + p.SinkType
 }
 
@@ -45,7 +55,7 @@ func testPayload() sink.Payload {
 }
 
 func TestSinkType(t *testing.T) {
-	s := New(&stubRenderer{})
+	s := New(&stubRenderer{defaultText: "rendered:slack"})
 	assert.Equal(t, "slack", s.Type())
 }
 
@@ -69,13 +79,303 @@ func TestSendSuccess(t *testing.T) {
 	defer server.Close()
 
 	cfg, _ := json.Marshal(config{WebhookURL: server.URL})
-	s := New(&stubRenderer{}, WithHTTPClient(&http.Client{Timeout: 5 * time.Second}))
+	s := New(&stubRenderer{defaultText: "rendered:slack"}, WithHTTPClient(&http.Client{Timeout: 5 * time.Second}))
 	err := s.Send(context.Background(), testPayload(), sink.SendOptions{
 		Config: cfg,
 	})
 
 	require.NoError(t, err)
 	assert.Contains(t, receivedText, "rendered:")
+}
+
+func TestSendJSONPresetWithoutTemplate(t *testing.T) {
+	var payload map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(body, &payload))
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok")) //nolint:errcheck
+	}))
+	defer server.Close()
+
+	cfg, _ := json.Marshal(config{WebhookURL: server.URL, Format: "json", BlockLayout: "default"})
+	s := New(&stubRenderer{defaultText: "rendered:slack"}, WithHTTPClient(&http.Client{Timeout: 5 * time.Second}))
+	err := s.Send(context.Background(), testPayload(), sink.SendOptions{Config: cfg})
+
+	require.NoError(t, err)
+	text, _ := payload["text"].(string)
+	assert.Contains(t, text, "[Start]")
+	assert.Contains(t, text, "default/test-plan")
+
+	blocks, ok := payload["blocks"].([]any)
+	require.True(t, ok)
+	assert.NotEmpty(t, blocks)
+}
+
+func TestSendJSONTemplateMessageObject(t *testing.T) {
+	var payload map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(body, &payload))
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok")) //nolint:errcheck
+	}))
+	defer server.Close()
+
+	tmpl := `{"text":"custom fallback","blocks":[{"type":"section","text":{"type":"mrkdwn","text":"hello"}}]}`
+	cfg, _ := json.Marshal(config{WebhookURL: server.URL, Format: "json"})
+	s := New(&stubRenderer{defaultText: "rendered:slack"}, WithHTTPClient(&http.Client{Timeout: 5 * time.Second}))
+	err := s.Send(context.Background(), testPayload(), sink.SendOptions{
+		Config: cfg,
+		CustomTemplate: &sink.CustomTemplate{
+			Content: tmpl,
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "custom fallback", payload["text"])
+	blocks, ok := payload["blocks"].([]any)
+	require.True(t, ok)
+	assert.Len(t, blocks, 1)
+}
+
+func TestSendJSONTemplateArrayPayload(t *testing.T) {
+	var payload map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(body, &payload))
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok")) //nolint:errcheck
+	}))
+	defer server.Close()
+
+	tmpl := `[{"type":"section","text":{"type":"mrkdwn","text":"from array"}}]`
+	cfg, _ := json.Marshal(config{WebhookURL: server.URL, Format: "json"})
+	s := New(&stubRenderer{defaultText: "rendered:slack"}, WithHTTPClient(&http.Client{Timeout: 5 * time.Second}))
+	err := s.Send(context.Background(), testPayload(), sink.SendOptions{
+		Config:         cfg,
+		CustomTemplate: &sink.CustomTemplate{Content: tmpl},
+	})
+
+	require.NoError(t, err)
+	text, _ := payload["text"].(string)
+	assert.Contains(t, text, "[Start]")
+	blocks, ok := payload["blocks"].([]any)
+	require.True(t, ok)
+	assert.Len(t, blocks, 1)
+}
+
+func TestSendJSONTemplateInvalidFallsBackToPreset(t *testing.T) {
+	var payload map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(body, &payload))
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok")) //nolint:errcheck
+	}))
+	defer server.Close()
+
+	cfg, _ := json.Marshal(config{WebhookURL: server.URL, Format: "json", BlockLayout: "compact"})
+	s := New(&stubRenderer{defaultText: "rendered:slack"}, WithHTTPClient(&http.Client{Timeout: 5 * time.Second}))
+	err := s.Send(context.Background(), testPayload(), sink.SendOptions{
+		Config:         cfg,
+		CustomTemplate: &sink.CustomTemplate{Content: "not-json"},
+	})
+
+	require.NoError(t, err)
+	text, _ := payload["text"].(string)
+	assert.Contains(t, text, "[Start]")
+	blocks, ok := payload["blocks"].([]any)
+	require.True(t, ok)
+	assert.NotEmpty(t, blocks)
+}
+
+func TestSendJSONRejectsRemovedPerTargetAlias(t *testing.T) {
+	cfg, _ := json.Marshal(config{WebhookURL: "https://hooks.slack.com/services/test", Format: "json", BlockLayout: "per_target"})
+	s := New(&stubRenderer{defaultText: "rendered:slack"}, WithHTTPClient(&http.Client{Timeout: 5 * time.Second}))
+	err := s.Send(context.Background(), testPayload(), sink.SendOptions{Config: cfg})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "block_layout must be one of")
+}
+
+func TestSendJSONProgressLayoutFallsBackForNonProgressEvent(t *testing.T) {
+	var bodyRaw string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		bodyRaw = string(body)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok")) //nolint:errcheck
+	}))
+	defer server.Close()
+
+	cfg, _ := json.Marshal(config{WebhookURL: server.URL, Format: "json", BlockLayout: "progress"})
+	s := New(&stubRenderer{defaultText: "rendered:slack"}, WithHTTPClient(&http.Client{Timeout: 5 * time.Second}))
+	err := s.Send(context.Background(), testPayload(), sink.SendOptions{Config: cfg})
+
+	require.NoError(t, err)
+	assert.Contains(t, bodyRaw, "Hibernation Starting")
+	assert.NotContains(t, bodyRaw, "Execution Progress")
+}
+
+func TestSendJSONPresetMaxTargets(t *testing.T) {
+	var bodyRaw string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		bodyRaw = string(body)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok")) //nolint:errcheck
+	}))
+	defer server.Close()
+
+	p := testPayload()
+	p.Event = "Failure"
+	p.Phase = string(hibernatorv1alpha1.PhaseError)
+	p.ErrorMessage = "boom"
+	p.Targets = []sink.TargetInfo{
+		{Name: "zeta", Executor: "rds", State: "Completed"},
+		{Name: "alpha", Executor: "eks", State: "Failed"},
+		{Name: "beta", Executor: "ec2", State: "Completed"},
+	}
+
+	cfg, _ := json.Marshal(config{WebhookURL: server.URL, Format: "json", BlockLayout: "default", MaxTargets: 2})
+	s := New(&stubRenderer{defaultText: "rendered:slack"}, WithHTTPClient(&http.Client{Timeout: 5 * time.Second}))
+	err := s.Send(context.Background(), p, sink.SendOptions{Config: cfg})
+
+	require.NoError(t, err)
+	assert.Contains(t, bodyRaw, "... and 1 more target(s)")
+	assert.Contains(t, bodyRaw, "alpha")
+}
+
+func TestSendJSONPresetDefaultScopeLine(t *testing.T) {
+	var bodyRaw string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		bodyRaw = string(body)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok")) //nolint:errcheck
+	}))
+	defer server.Close()
+
+	p := testPayload()
+	p.Event = "Failure"
+	p.Targets = []sink.TargetInfo{
+		{
+			Name:     "rds-main",
+			Executor: "rds",
+			State:    "Failed",
+			Connector: sink.ConnectorInfo{
+				AccountID:   "123456789012",
+				ClusterName: "prod-eks",
+			},
+		},
+	}
+
+	cfg, _ := json.Marshal(config{WebhookURL: server.URL, Format: formatJSON, BlockLayout: blockLayoutDefault})
+	s := New(&stubRenderer{defaultText: "rendered:slack"}, WithHTTPClient(&http.Client{Timeout: 5 * time.Second}))
+	err := s.Send(context.Background(), p, sink.SendOptions{Config: cfg})
+
+	require.NoError(t, err)
+	assert.Contains(t, bodyRaw, "*Account:* `123456789012`")
+	assert.Contains(t, bodyRaw, "*Cluster:* `prod-eks`")
+}
+
+func TestSendJSONPresetAdditionalScopes(t *testing.T) {
+	var bodyRaw string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		bodyRaw = string(body)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok")) //nolint:errcheck
+	}))
+	defer server.Close()
+
+	p := testPayload()
+	p.Plan.Labels = map[string]string{"env": "prod"}
+	p.Targets = []sink.TargetInfo{
+		{
+			Name:     "rds-main",
+			Executor: "rds",
+			State:    "Failed",
+			Connector: sink.ConnectorInfo{
+				AccountID:   "123456789012",
+				ClusterName: "prod-eks",
+				Region:      "us-east-1",
+				Provider:    "aws",
+			},
+		},
+	}
+
+	cfg, _ := json.Marshal(config{
+		WebhookURL:       server.URL,
+		Format:           formatJSON,
+		BlockLayout:      blockLayoutCompact,
+		AdditionalScopes: []string{"environment", "region", "provider"},
+	})
+	s := New(&stubRenderer{defaultText: "rendered:slack"}, WithHTTPClient(&http.Client{Timeout: 5 * time.Second}))
+	err := s.Send(context.Background(), p, sink.SendOptions{Config: cfg})
+
+	require.NoError(t, err)
+	assert.Contains(t, bodyRaw, "*Account:* `123456789012`")
+	assert.Contains(t, bodyRaw, "*Cluster:* `prod-eks`")
+	assert.Contains(t, bodyRaw, "*Environment:* `prod`")
+	assert.Contains(t, bodyRaw, "*Region:* `us-east-1`")
+	assert.Contains(t, bodyRaw, "*Provider:* `aws`")
+}
+
+func TestSendJSONPresetAdditionalScopesEnvAlias(t *testing.T) {
+	var bodyRaw string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		bodyRaw = string(body)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok")) //nolint:errcheck
+	}))
+	defer server.Close()
+
+	p := testPayload()
+	p.Plan.Annotations = map[string]string{"environment": "staging"}
+	p.Targets = []sink.TargetInfo{
+		{
+			Name:     "eks-app",
+			Executor: "eks",
+			State:    "Completed",
+			Connector: sink.ConnectorInfo{
+				AccountID:   "111111111111",
+				ClusterName: "staging-eks",
+			},
+		},
+	}
+
+	cfg, _ := json.Marshal(config{
+		WebhookURL:       server.URL,
+		Format:           formatJSON,
+		BlockLayout:      blockLayoutDefault,
+		AdditionalScopes: []string{"env"},
+	})
+	s := New(&stubRenderer{defaultText: "rendered:slack"}, WithHTTPClient(&http.Client{Timeout: 5 * time.Second}))
+	err := s.Send(context.Background(), p, sink.SendOptions{Config: cfg})
+
+	require.NoError(t, err)
+	assert.Contains(t, bodyRaw, "*Environment:* `staging`")
 }
 
 func TestSendHTTPError(t *testing.T) {
@@ -86,7 +386,7 @@ func TestSendHTTPError(t *testing.T) {
 	defer server.Close()
 
 	cfg, _ := json.Marshal(config{WebhookURL: server.URL})
-	s := New(&stubRenderer{}, WithHTTPClient(&http.Client{Timeout: 5 * time.Second}))
+	s := New(&stubRenderer{defaultText: "rendered:slack"}, WithHTTPClient(&http.Client{Timeout: 5 * time.Second}))
 	err := s.Send(context.Background(), testPayload(), sink.SendOptions{
 		Config: cfg,
 	})
@@ -103,7 +403,7 @@ func TestSendRateLimited(t *testing.T) {
 	defer server.Close()
 
 	cfg, _ := json.Marshal(config{WebhookURL: server.URL})
-	s := New(&stubRenderer{}, WithHTTPClient(&http.Client{Timeout: 5 * time.Second}))
+	s := New(&stubRenderer{defaultText: "rendered:slack"}, WithHTTPClient(&http.Client{Timeout: 5 * time.Second}))
 	err := s.Send(context.Background(), testPayload(), sink.SendOptions{
 		Config: cfg,
 	})
@@ -123,7 +423,7 @@ func TestSendContextCanceled(t *testing.T) {
 	cancel()
 
 	cfg, _ := json.Marshal(config{WebhookURL: server.URL})
-	s := New(&stubRenderer{}, WithHTTPClient(&http.Client{Timeout: 5 * time.Second}))
+	s := New(&stubRenderer{defaultText: "rendered:slack"}, WithHTTPClient(&http.Client{Timeout: 5 * time.Second}))
 	err := s.Send(ctx, testPayload(), sink.SendOptions{
 		Config: cfg,
 	})
@@ -133,7 +433,7 @@ func TestSendContextCanceled(t *testing.T) {
 
 func TestSendInvalidURL(t *testing.T) {
 	cfg, _ := json.Marshal(config{WebhookURL: "://invalid"})
-	s := New(&stubRenderer{}, WithHTTPClient(&http.Client{Timeout: 5 * time.Second}))
+	s := New(&stubRenderer{defaultText: "rendered:slack"}, WithHTTPClient(&http.Client{Timeout: 5 * time.Second}))
 	err := s.Send(context.Background(), testPayload(), sink.SendOptions{
 		Config: cfg,
 	})
@@ -143,7 +443,7 @@ func TestSendInvalidURL(t *testing.T) {
 
 func TestSendMissingWebhookURL(t *testing.T) {
 	cfg, _ := json.Marshal(config{})
-	s := New(&stubRenderer{}, WithHTTPClient(&http.Client{Timeout: 5 * time.Second}))
+	s := New(&stubRenderer{defaultText: "rendered:slack"}, WithHTTPClient(&http.Client{Timeout: 5 * time.Second}))
 	err := s.Send(context.Background(), testPayload(), sink.SendOptions{Config: cfg})
 
 	require.Error(t, err)
@@ -151,9 +451,158 @@ func TestSendMissingWebhookURL(t *testing.T) {
 }
 
 func TestSendInvalidConfig(t *testing.T) {
-	s := New(&stubRenderer{}, WithHTTPClient(&http.Client{Timeout: 5 * time.Second}))
+	s := New(&stubRenderer{defaultText: "rendered:slack"}, WithHTTPClient(&http.Client{Timeout: 5 * time.Second}))
 	err := s.Send(context.Background(), testPayload(), sink.SendOptions{Config: []byte("not json")})
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "parse slack sink config")
+}
+
+func TestSendInvalidFormat(t *testing.T) {
+	cfg, _ := json.Marshal(config{WebhookURL: "https://hooks.slack.com/services/test", Format: "yaml"})
+	s := New(&stubRenderer{defaultText: "rendered:slack"}, WithHTTPClient(&http.Client{Timeout: 5 * time.Second}))
+	err := s.Send(context.Background(), testPayload(), sink.SendOptions{Config: cfg})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "format must be")
+}
+
+func TestSendInvalidBlockLayout(t *testing.T) {
+	cfg, _ := json.Marshal(config{WebhookURL: "https://hooks.slack.com/services/test", Format: "json", BlockLayout: "oncall"})
+	s := New(&stubRenderer{defaultText: "rendered:slack"}, WithHTTPClient(&http.Client{Timeout: 5 * time.Second}))
+	err := s.Send(context.Background(), testPayload(), sink.SendOptions{Config: cfg})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "block_layout must be one of")
+}
+
+func TestSendInvalidAdditionalScope(t *testing.T) {
+	cfg, _ := json.Marshal(config{
+		WebhookURL:       "https://hooks.slack.com/services/test",
+		Format:           "json",
+		BlockLayout:      "default",
+		AdditionalScopes: []string{"foobar"},
+	})
+	s := New(&stubRenderer{defaultText: "rendered:slack"}, WithHTTPClient(&http.Client{Timeout: 5 * time.Second}))
+	err := s.Send(context.Background(), testPayload(), sink.SendOptions{Config: cfg})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported additional scope")
+}
+
+func TestSendTextIgnoresInvalidBlockLayout(t *testing.T) {
+	var payload map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(body, &payload))
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok")) //nolint:errcheck
+	}))
+	defer server.Close()
+
+	cfg, _ := json.Marshal(config{WebhookURL: server.URL, Format: "text", BlockLayout: "oncall"})
+	s := New(&stubRenderer{defaultText: "rendered:slack"}, WithHTTPClient(&http.Client{Timeout: 5 * time.Second}))
+	err := s.Send(context.Background(), testPayload(), sink.SendOptions{Config: cfg})
+
+	require.NoError(t, err)
+	assert.Equal(t, "rendered:slack", payload["text"])
+	_, hasBlocks := payload["blocks"]
+	assert.False(t, hasBlocks)
+}
+
+func TestParseJSONTemplateMessageAddsFallbackTextWhenMissing(t *testing.T) {
+	rendered := `{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":"hello"}}]}`
+	msg, err := parseJSONTemplateMessage(rendered, testPayload())
+
+	require.NoError(t, err)
+	require.NotNil(t, msg)
+	require.NotNil(t, msg.Blocks)
+	assert.NotEmpty(t, msg.Blocks.BlockSet)
+	assert.Contains(t, msg.Text, "[Start]")
+}
+
+func TestParseJSONTemplateMessageArray(t *testing.T) {
+	rendered := `[{"type":"section","text":{"type":"mrkdwn","text":"hello"}}]`
+	msg, err := parseJSONTemplateMessage(rendered, testPayload())
+
+	require.NoError(t, err)
+	require.NotNil(t, msg)
+	require.NotNil(t, msg.Blocks)
+	assert.Len(t, msg.Blocks.BlockSet, 1)
+	assert.Contains(t, msg.Text, "[Start]")
+}
+
+func TestParseJSONTemplateMessageInvalid(t *testing.T) {
+	_, err := parseJSONTemplateMessage("not-json", testPayload())
+	require.Error(t, err)
+}
+
+func TestConfigUseDefaults(t *testing.T) {
+	cfg := config{}
+	cfg.useDefaults()
+
+	assert.Equal(t, formatText, cfg.Format)
+	assert.Equal(t, blockLayoutDefault, cfg.BlockLayout)
+	assert.Equal(t, defaultMaxTargets, cfg.MaxTargets)
+	assert.Empty(t, cfg.AdditionalScopes)
+}
+
+func TestConfigUseDefaults_NormalizeAdditionalScopes(t *testing.T) {
+	cfg := config{AdditionalScopes: []string{" env ", "ACCOUNT_ID", "cluster_id", "environment", "env"}}
+	cfg.useDefaults()
+
+	assert.Equal(t, []string{scopeEnvironment, scopeAccount, scopeCluster}, cfg.AdditionalScopes)
+}
+
+func TestLayoutFactory_UnknownLayoutFallsBackToDefault(t *testing.T) {
+	p := testPayload()
+	composer := newLayoutComposer(p, defaultMaxTargets, nil)
+	factory := newLayoutFactory()
+
+	blocks := factory.build("unknown-layout", composer)
+	require.NotEmpty(t, blocks)
+
+	raw, err := json.Marshal(blocks)
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), "Hibernation Starting")
+}
+
+func TestLayoutFactory_ProgressFallsBackForNonProgressEvent(t *testing.T) {
+	p := testPayload() // Event=Start
+	composer := newLayoutComposer(p, defaultMaxTargets, nil)
+	factory := newLayoutFactory()
+
+	blocks := factory.build(blockLayoutProgress, composer)
+	require.NotEmpty(t, blocks)
+
+	raw, err := json.Marshal(blocks)
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), "Hibernation Starting")
+	assert.NotContains(t, string(raw), "Execution Progress")
+}
+
+func TestLayoutFactory_ProgressUsesProgressLayoutForExecutionProgress(t *testing.T) {
+	p := testPayload()
+	p.Event = "ExecutionProgress"
+	p.TargetExecution = &sink.TargetInfo{
+		Name:     "rds-main",
+		Executor: "rds",
+		State:    "Running",
+		Message:  "stopping",
+	}
+	p.Operation = "shutdown"
+
+	composer := newLayoutComposer(p, defaultMaxTargets, nil)
+	factory := newLayoutFactory()
+
+	blocks := factory.build(blockLayoutProgress, composer)
+	require.NotEmpty(t, blocks)
+
+	raw, err := json.Marshal(blocks)
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), "Execution Progress")
+	assert.Contains(t, string(raw), "rds-main")
+	assert.Contains(t, string(raw), fmt.Sprintf("*Operation:* %s", p.Operation))
 }

--- a/internal/notification/sink/slack/utils.go
+++ b/internal/notification/sink/slack/utils.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2026 Ardika Saputro.
+Licensed under the Apache License, Version 2.0.
+*/
+
+package slack
+
+import (
+	"strings"
+
+	slackapi "github.com/slack-go/slack"
+)
+
+type textBlockBuilder struct {
+	elementType string
+	text        string
+	emoji       bool
+	verbatim    bool
+}
+
+func mdText() *textBlockBuilder {
+	return &textBlockBuilder{elementType: slackapi.MarkdownType}
+}
+
+func plainText() *textBlockBuilder {
+	return &textBlockBuilder{elementType: slackapi.PlainTextType}
+}
+
+func (b *textBlockBuilder) WithText(text string) *textBlockBuilder {
+	b.text = text
+	return b
+}
+
+func (b *textBlockBuilder) WithEmoji() *textBlockBuilder {
+	b.emoji = true
+	return b
+}
+
+func (b *textBlockBuilder) WithoutEmoji() *textBlockBuilder {
+	b.emoji = false
+	return b
+}
+
+func (b *textBlockBuilder) WithVerbatim() *textBlockBuilder {
+	b.verbatim = true
+	return b
+}
+
+func (b *textBlockBuilder) Build() *slackapi.TextBlockObject {
+	return slackapi.NewTextBlockObject(b.elementType, b.text, b.emoji, b.verbatim)
+}
+
+type blockSetBuilder struct {
+	blocks []slackapi.Block
+}
+
+func newBlockSetBuilder(capacity int) *blockSetBuilder {
+	if capacity < 0 {
+		capacity = 0
+	}
+	return &blockSetBuilder{blocks: make([]slackapi.Block, 0, capacity)}
+}
+
+func (b *blockSetBuilder) Add(blocks ...slackapi.Block) *blockSetBuilder {
+	b.blocks = append(b.blocks, blocks...)
+	return b
+}
+
+func (b *blockSetBuilder) AddWhen(condition bool, block slackapi.Block) *blockSetBuilder {
+	if condition {
+		b.blocks = append(b.blocks, block)
+	}
+	return b
+}
+
+func (b *blockSetBuilder) AddWhenText(text string, factory func(string) slackapi.Block) *blockSetBuilder {
+	if strings.TrimSpace(text) == "" {
+		return b
+	}
+	b.blocks = append(b.blocks, factory(text))
+	return b
+}
+
+func (b *blockSetBuilder) AddWhenTextBlocks(text string, factory func(string) []slackapi.Block) *blockSetBuilder {
+	if strings.TrimSpace(text) == "" {
+		return b
+	}
+	b.blocks = append(b.blocks, factory(text)...)
+	return b
+}
+
+func (b *blockSetBuilder) Build() []slackapi.Block {
+	return b.blocks
+}

--- a/website/docs/reference/notification-sinks.md
+++ b/website/docs/reference/notification-sinks.md
@@ -19,19 +19,31 @@ _Sink type: `slack`_
 
 Delivers messages via [Slack Incoming Webhooks](https://api.slack.com/messaging/webhooks).
 
+!!! tip "Formatting Message Text (Slack)"
+    When `format: json` is configured, message content is rendered using Slack message formatting semantics (`mrkdwn`/`plain_text`).
+    See Slack docs: [Formatting message text](https://docs.slack.dev/messaging/formatting-message-text/).
+
 ### Configuration
 
 The configuration must be in a JSON object stored under `config` key in secret reference:
 
 ```json
 {
-  "webhook_url": "<webhook_url>"
+  "webhook_url": "<webhook_url>",
+  "format": "<format>",
+  "block_layout": "<block_layout>",
+  "max_targets": "<max_targets>",
+  "additional_scopes": "<additional_scopes>"
 }
 ```
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `webhook_url` | `string` | Yes | WebhookURL is the Slack Incoming Webhook URL. |
+| `format` | `string` | No | Format controls Slack payload mode. Supported values: `text` (message text only), and `json` (Slack blocks payload, using preset layouts or custom templates). |
+| `block_layout` | `string` | No | BlockLayout selects the preset JSON layout used when format=json and no custom JSON template is provided (or parsing fails). Supported values: `default`, `compact`, `progress`. |
+| `max_targets` | `int` | No | MaxTargets limits target lines in preset JSON layouts. It defaults to 8, which is enough to show all targets in most cases while keeping the message concise. |
+| `additional_scopes` | `[]string` | No | AdditionalScopes appends additional scope fields to the scope context. Account and Cluster are always included by default. Supported: `environment` (alias: env), `region`, `project`, `provider`, `connector`, `account`, `cluster`. |
 
 ### Default Template
 

--- a/website/docs/user-guides/notifications.md
+++ b/website/docs/user-guides/notifications.md
@@ -51,6 +51,29 @@ Each sink reads its configuration from a Kubernetes Secret. The Secret must cont
         }
     ```
 
+    Optional advanced Slack config:
+
+    ```json
+    {
+      "webhook_url": "https://hooks.slack.com/services/T00/B00/xxxx",
+      "format": "json",
+      "block_layout": "default",
+      "max_targets": 8,
+      "additional_scopes": ["environment", "region"]
+    }
+    ```
+
+    - `format: text` (default): sends plain Slack text.
+    - `format: json`: sends Slack blocks JSON.
+      - if `templateRef` exists, template output is parsed as Slack JSON payload.
+      - if no `templateRef` (or JSON parse fails), built-in preset layout is used.
+    - `block_layout`: preset for JSON mode (`default`, `compact`, `progress`).
+      - `progress` is optimized for `ExecutionProgress` events.
+    - `max_targets`: maximum target lines in preset JSON output.
+    - `additional_scopes`: appends extra bottom scope metadata context.
+      - defaults already include Account and Cluster.
+      - supported values: `environment` (alias `env`), `region`, `project`, `provider`, `connector`, `account`, `cluster`.
+
 === "Telegram"
 
     ```yaml
@@ -191,6 +214,11 @@ spec:
 
 By default, each sink uses a built-in template that produces a well-formatted message with event indicators, plan details, phase, targets, and error information. To customize the message format, create a ConfigMap with a Go template and reference it via `templateRef`:
 
+For Slack:
+
+- with `format=text`, your template should render plain text.
+- with `format=json`, your template should render a Slack JSON payload (typically with `blocks`, optionally with `text`).
+
 ### Step 1: Create the Template ConfigMap
 
 ```yaml
@@ -213,6 +241,35 @@ data:
     *Operation:* {{ .Operation | default "N/A" }}
     {{ if .ErrorMessage }}*Error:* {{ .ErrorMessage }}{{ end }}
     *Time:* {{ .Timestamp | date "2006-01-02 15:04:05 MST" }}
+```
+
+Slack JSON template example (`format=json`):
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: slack-json-templates
+  namespace: hibernator-system
+data:
+  template.gotpl: |
+    {{- $fallback := printf "[%s] %s/%s phase=%s" .Event .Plan.Namespace .Plan.Name .Phase -}}
+    {
+      "text": {{ $fallback | toJson }},
+      "blocks": [
+        {
+          "type": "header",
+          "text": { "type": "plain_text", "text": "Hibernator Notification" }
+        },
+        {
+          "type": "section",
+          "text": {
+            "type": "mrkdwn",
+            "text": {{ (printf "*Event:* %s\\n*Plan:* `%s/%s`\\n*Phase:* `%s`" .Event .Plan.Namespace .Plan.Name .Phase) | toJson }}
+          }
+        }
+      ]
+    }
 ```
 
 ### Step 2: Reference It in the Sink


### PR DESCRIPTION
# Add Slack Block Kit support to notifications (from text-only), with layout factory/composer refactor

Currently, Hibernator Slack notifications were text-only.  
This PR introduces support for Slack Block Kit payloads while preserving existing text behavior by default.

Hence, the goals is:
- Backward-compatible text notifications (format=text)
- New structured block notifications (format=json)
- Cleaner internal rendering architecture for maintainability.