### PR TITLE
feat: using keyedworker pool for notification handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,6 +174,15 @@ test-e2e: envtest ginkgo ## Run E2E tests in parallel via Ginkgo multi-process.
 	@echo "$(CYAN)Running E2E tests (procs=$(E2E_PROCS))...$(RESET)"
 	@KUBEBUILDER_ASSETS=$$($(ENVTEST) use -p path 2>/dev/null) $(GINKGO) --procs=$(E2E_PROCS) --tags=e2e -v ./test/e2e/...
 
+.PHONY: test-e2e-focus
+test-e2e-focus: envtest ## Run E2E tests matching a specific prefix. Usage: make test-e2e-focus FOCUS="Notification"
+	@if [ -z "$(FOCUS)" ]; then \
+		echo "$(RED)Error: FOCUS is required. Usage: make test-e2e-focus FOCUS=\"Notification\"$(RESET)"; \
+		exit 1; \
+	fi
+	@echo "$(CYAN)Running E2E tests with focus: $(FOCUS)...$(RESET)"
+	@$(GOCMD) test ./test/e2e/ -v -tags=e2e -ginkgo.v -ginkgo.focus="$(FOCUS)"
+
 .PHONY: test-pkg
 test-pkg: ## Run tests for a specific package. Usage: make test-pkg PKG=./internal/scheduler/...
 	@if [ -z "$(PKG)" ]; then \

--- a/docs/plan/notification-keyedworker-revamp.md
+++ b/docs/plan/notification-keyedworker-revamp.md
@@ -69,17 +69,18 @@ This key ensures all requests belonging to the same sink execution stream are se
 3. **Adaptive lifecycle:** worker spawns lazily and reaps after idle TTL.
 4. **Shutdown drain:** queued per-stream items are drained before dispatcher stops.
 5. **Saturation behavior:** per-stream full buffer causes controlled drops and increments drop metric.
+6. **E2E ordering verification:** End-to-end test verifying ExecutionProgress arrives before Success for the same cycle.
 
 ## Implementation Checklist
 
-- [ ] Introduce stream key and key builder in notification dispatcher.
-- [ ] Replace shared queue worker model with keyedworker pool model.
-- [ ] Implement per-stream FIFO slot with drop callback for metrics.
-- [ ] Remove overflow queue/drainer logic from dispatcher.
-- [ ] Add worker idle TTL config and defaults.
-- [ ] Add active stream worker gauge metric.
-- [ ] Update dispatcher tests to keyed-stream behavior.
-- [ ] Run notification package tests and fix regressions.
+- [x] Introduce stream key and key builder in notification dispatcher.
+- [x] Replace shared queue worker model with keyedworker pool model.
+- [x] Implement per-stream FIFO slot with drop callback for metrics.
+- [x] Remove overflow queue/drainer logic from dispatcher.
+- [x] Add worker idle TTL config and defaults.
+- [x] Add active stream worker gauge metric.
+- [x] Update dispatcher tests to keyed-stream behavior.
+- [x] Run notification package tests and fix regressions.
 
 ## Out of Scope
 

--- a/docs/plan/notification-keyedworker-revamp.md
+++ b/docs/plan/notification-keyedworker-revamp.md
@@ -1,0 +1,88 @@
+# Notification Dispatcher Revamp: Keyed FIFO Stream Workers
+
+## Background
+
+We received a race-condition report where sink notifications for `ExecutionProgress` and `Success` can be observed out of order. The current dispatcher uses a shared queue and fixed worker pool, which allows concurrent handling of requests from the same logical sink stream.
+
+This revamp replaces the fixed global worker model with adaptive per-stream keyed workers to guarantee deterministic ordering per stream while preserving parallelism across different streams.
+
+## Goals
+
+- Guarantee FIFO ordering per notification stream at sink level.
+- Keep parallelism across independent streams.
+- Remove global overflow queue complexity.
+- Keep non-blocking `Submit` behavior.
+- Preserve graceful shutdown delivery for queued items.
+
+## Stream Definition
+
+Each request is routed by a stream key:
+
+- plan namespace/name
+- cycle ID
+- notification namespace/name
+- sink name
+- sink type
+- operation
+
+This key ensures all requests belonging to the same sink execution stream are serialized by a single worker.
+
+## Design
+
+### 1) Dispatcher execution model
+
+- Replace shared channel + fixed workers with `keyedworker.Pool[streamKey, Request]`.
+- Use per-stream FIFO slot semantics.
+- Enable adaptive worker lifecycle:
+  - lazy spawn on first delivery,
+  - idle reap after configurable TTL,
+  - auto-remove idle stream entries.
+
+### 2) Overflow deprecation
+
+- Remove global overflow queue and drainer loop.
+- Per-stream buffering uses bounded FIFO slots.
+- On per-stream buffer saturation, drop request and increment `NotificationDropTotal`.
+
+### 3) Shutdown behavior
+
+- Keep `Submit` fast-path shutdown gate (`done` channel).
+- On worker context cancellation, drain pending slot items with a bounded timeout before exit.
+- Ensure no send-on-closed-channel risk (no shared request channel to close).
+
+### 4) Configuration
+
+- Remove legacy `DispatcherConfig.Workers` and `DispatcherConfig.MaxOverflowSize`.
+- Continue using `ChannelSize` as **per-stream** buffer size.
+- Add `WorkerIdleTTL` to tune adaptive stream worker reap behavior.
+
+## Metrics and Observability
+
+- Keep existing notification metrics (`sent`, `errors`, `latency`, `drop`).
+- Add gauge for active notification stream workers.
+- Emit structured logs on stream worker start/stop and stream-key context.
+
+## Test Plan
+
+1. **Ordering (same stream):** `ExecutionProgress` then `Success` must dispatch in order.
+2. **Parallelism (different streams):** one blocked stream must not block another.
+3. **Adaptive lifecycle:** worker spawns lazily and reaps after idle TTL.
+4. **Shutdown drain:** queued per-stream items are drained before dispatcher stops.
+5. **Saturation behavior:** per-stream full buffer causes controlled drops and increments drop metric.
+
+## Implementation Checklist
+
+- [ ] Introduce stream key and key builder in notification dispatcher.
+- [ ] Replace shared queue worker model with keyedworker pool model.
+- [ ] Implement per-stream FIFO slot with drop callback for metrics.
+- [ ] Remove overflow queue/drainer logic from dispatcher.
+- [ ] Add worker idle TTL config and defaults.
+- [ ] Add active stream worker gauge metric.
+- [ ] Update dispatcher tests to keyed-stream behavior.
+- [ ] Run notification package tests and fix regressions.
+
+## Out of Scope
+
+- Durable notification queue/outbox persistence.
+- Feature flag for old/new dispatcher selection.
+- API-level breaking config cleanup (can be done later after stabilization).

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -216,4 +216,13 @@ var (
 		},
 		[]string{"sink_type", "event"},
 	)
+
+	// NotificationWorkerGoroutinesGauge tracks the number of live keyed stream
+	// workers in the notification dispatcher.
+	NotificationWorkerGoroutinesGauge = factory.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "hibernator_notification_worker_goroutines",
+			Help: "Number of live per-stream notification worker goroutines",
+		},
+	)
 )

--- a/internal/notification/dispatcher.go
+++ b/internal/notification/dispatcher.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"maps"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -110,10 +109,6 @@ type Dispatcher struct {
 
 	// activeWorkerCount tracks the number of currently active workers for graceful shutdown.
 	activeWorkerCount atomic.Int64
-
-	// readiness represents the completion of Start.
-	// Submit waits on this to ensure Start has completed before accepting requests.
-	readiness *sync.WaitGroup
 }
 
 type streamKey struct {
@@ -151,7 +146,6 @@ func NewDispatcher(log logr.Logger, c client.Reader, registry *sink.Registry, cf
 		dispatchTimeout: cfg.DispatchTimeout,
 		workerIdleTTL:   cfg.WorkerIdleTTL,
 		done:            make(chan struct{}),
-		readiness:       new(sync.WaitGroup),
 	}
 
 	d.pool = keyedworker.New(
@@ -170,7 +164,6 @@ func NewDispatcher(log logr.Logger, c client.Reader, registry *sink.Registry, cf
 		keyedworker.WithLogger[streamKey, Request](log.WithName("pool")),
 	)
 
-	d.readiness.Add(1)
 	return d
 }
 
@@ -205,9 +198,8 @@ func (d *Dispatcher) Start(ctx context.Context) error {
 	)
 
 	d.pool.Register(ctx, d.workerFactory)
-	d.log.V(1).Info("notification dispatcher running", "mode", "keyed-stream")
-	d.readiness.Done()
 
+	d.log.V(1).Info("notification dispatcher running", "mode", "keyed-stream")
 	<-ctx.Done()
 	d.log.V(1).Info("notification dispatcher initiating shutdown")
 	close(d.done)
@@ -242,8 +234,6 @@ waitLoop:
 // is dropped by the slot and counted in NotificationDropTotal.
 // After shutdown begins (d.done closed), requests are discarded with a metric.
 func (d *Dispatcher) Submit(req Request) {
-	d.readiness.Wait() // ensure Start has completed before accepting requests
-
 	log := d.log.WithValues(
 		"plan", req.Payload.Plan.String(),
 		"sink", req.SinkName,

--- a/internal/notification/dispatcher.go
+++ b/internal/notification/dispatcher.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"maps"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -21,6 +22,7 @@ import (
 	hibernatorv1alpha1 "github.com/ardikabs/hibernator/api/v1alpha1"
 	"github.com/ardikabs/hibernator/internal/metrics"
 	"github.com/ardikabs/hibernator/internal/notification/sink"
+	"github.com/ardikabs/hibernator/pkg/keyedworker"
 )
 
 const (
@@ -36,14 +38,11 @@ const (
 	// defaultDrainTimeout is the maximum time to wait for workers to drain remaining items during shutdown.
 	defaultDrainTimeout = 30 * time.Second
 
+	// defaultWorkerIdleTTL is how long an idle per-stream worker stays alive.
+	defaultWorkerIdleTTL = 30 * time.Minute
+
 	// defaultChannelSize is the default buffered channel capacity for dispatch requests.
 	defaultChannelSize = 256
-
-	// defaultWorkers is the default number of concurrent dispatch goroutines.
-	defaultWorkers = 4
-
-	// defaultMaxOverflowSize is the default maximum number of requests allowed in the overflow queue before new requests are dropped.
-	defaultMaxOverflowSize = 4096
 )
 
 // DispatcherConfig holds tuning knobs for the notification Dispatcher.
@@ -53,17 +52,13 @@ type DispatcherConfig struct {
 	// Default: 256.
 	ChannelSize int
 
-	// Workers is the number of concurrent dispatch goroutines.
-	// Default: 4.
-	Workers int
-
 	// DispatchTimeout is the per-sink HTTP call timeout.
 	// Default: 5s.
 	DispatchTimeout time.Duration
 
-	// MaxOverflowSize is the maximum number of requests allowed in the overflow queue before new requests are dropped.
-	// Default: 4096.
-	MaxOverflowSize int
+	// WorkerIdleTTL is how long an idle per-stream worker stays alive before exiting.
+	// Default: 30m.
+	WorkerIdleTTL time.Duration
 }
 
 // withDefaults returns a copy with zero fields replaced by defaults.
@@ -71,25 +66,21 @@ func (c DispatcherConfig) withDefaults() DispatcherConfig {
 	if c.ChannelSize <= 0 {
 		c.ChannelSize = defaultChannelSize
 	}
-	if c.Workers <= 0 {
-		c.Workers = defaultWorkers
-	}
 	if c.DispatchTimeout <= 0 {
 		c.DispatchTimeout = defaultDispatchTimeout
 	}
-	if c.MaxOverflowSize <= 0 {
-		c.MaxOverflowSize = defaultMaxOverflowSize
+	if c.WorkerIdleTTL <= 0 {
+		c.WorkerIdleTTL = defaultWorkerIdleTTL
 	}
 	return c
 }
 
 // Dispatcher is a standalone controller-runtime Runnable that processes notification
 // dispatch requests asynchronously. Hook closures submit Requests via Submit, which
-// returns immediately (fire-and-forget). Requests flow through a buffered channel to
-// a pool of worker goroutines; when the channel is full, an internal overflow queue
-// absorbs the excess and a dedicated drainer goroutine feeds items back into the
-// channel as space becomes available. The caller never blocks and no request is dropped
-// during normal operation.
+// returns immediately (fire-and-forget). Requests are routed into per-stream FIFO
+// slots managed by keyedworker. Each stream is processed by at most one worker at
+// a time, guaranteeing deterministic ordering for that stream while preserving
+// concurrency across independent streams.
 //
 // The dispatcher:
 //   - resolves sink credentials (Secret lookup via informer cache)
@@ -102,63 +93,96 @@ type Dispatcher struct {
 	log             logr.Logger
 	client          client.Reader
 	registry        *sink.Registry
-	channelSize     int
-	workers         int
+	channelSize     int // per-stream buffer capacity
 	dispatchTimeout time.Duration
-	maxOverflowSize int
+	workerIdleTTL   time.Duration
 
 	// deliveryCallback is called after each dispatch attempt to report success/failure.
 	// Nil means no delivery tracking.
 	deliveryCallback DeliveryCallback
 
-	// requestCh is the primary buffered channel between Submit and workers.
-	// It is NEVER closed — workers exit via the allFlushed signal instead,
-	// which avoids send-on-closed-channel panics from concurrent Submit calls.
-	requestCh chan Request
-
 	// done is closed when the dispatcher begins shutting down.
 	// Submit checks this via non-blocking select for the fast-path discard.
 	done chan struct{}
 
-	// drained is closed after the drainer goroutine has fully stopped and returned
-	// any undrained items back to the overflow queue. This signals Start() that
-	// it's safe to flush the overflow queue into the channel without racing with the drainer.
-	drained chan struct{}
+	// pool manages per-stream workers and their request queues.
+	pool *keyedworker.Pool[streamKey, Request]
 
-	// flushed is closed after overflow has been fully flushed into requestCh.
-	// Workers switch from their main loop to a drain loop once this fires.
-	flushed chan struct{}
+	// activeWorkerCount tracks the number of currently active workers for graceful shutdown.
+	activeWorkerCount atomic.Int64
 
-	// overflow holds requests that couldn't fit in the channel when submitted.
-	//
-	// The overflow is concurrency-safe internally, but the dispatcher ensures that only the drainer goroutine mutates it,
-	// so no external locking is needed when the drainer appends or moves items back to the channel.
-	overflow *Overflow[Request]
+	// readiness represents the completion of Start.
+	// Submit waits on this to ensure Start has completed before accepting requests.
+	readiness *sync.WaitGroup
+}
 
-	// drainSignal is a 1-buffered channel used to wake the drainer goroutine
-	// when items are added to overflow.
-	drainSignal chan struct{}
+type streamKey struct {
+	Plan            types.NamespacedName
+	CycleID         string
+	NotificationRef types.NamespacedName
+	SinkName        string
+	SinkType        string
+	Operation       string
+}
+
+func streamKeyFromRequest(req Request) streamKey {
+	return streamKey{
+		Plan: types.NamespacedName{
+			Namespace: req.Payload.Plan.Namespace,
+			Name:      req.Payload.Plan.Name,
+		},
+		CycleID:         req.Payload.CycleID,
+		NotificationRef: req.NotificationRef,
+		SinkName:        req.SinkName,
+		SinkType:        req.SinkType,
+		Operation:       req.Payload.Operation,
+	}
 }
 
 // NewDispatcher creates a new NotificationDispatcher.
 // The client should be the cached reader (informer cache) for Secret lookups.
 func NewDispatcher(log logr.Logger, c client.Reader, registry *sink.Registry, cfg DispatcherConfig) *Dispatcher {
 	cfg = cfg.withDefaults()
-	return &Dispatcher{
+	d := &Dispatcher{
 		log:             log,
 		client:          c,
 		registry:        registry,
 		channelSize:     cfg.ChannelSize,
-		workers:         cfg.Workers,
 		dispatchTimeout: cfg.DispatchTimeout,
-		maxOverflowSize: cfg.MaxOverflowSize,
-		overflow:        new(Overflow[Request]),
-		requestCh:       make(chan Request, cfg.ChannelSize),
+		workerIdleTTL:   cfg.WorkerIdleTTL,
 		done:            make(chan struct{}),
-		drained:         make(chan struct{}),
-		flushed:         make(chan struct{}),
-		drainSignal:     make(chan struct{}, 1),
+		readiness:       new(sync.WaitGroup),
 	}
+
+	d.pool = keyedworker.New(
+		keyedworker.WithSlotFactory[streamKey](func() keyedworker.Slot[Request] {
+			return keyedworker.FIFOSlotWithOnDrop(cfg.ChannelSize, d.onRecordDrop)()
+		}),
+		keyedworker.WithAutoRemoveOnIdle[streamKey, Request](),
+		keyedworker.WithOnSpawnCallback[streamKey, Request](func(_ streamKey) {
+			d.activeWorkerCount.Add(1)
+			metrics.NotificationWorkerGoroutinesGauge.Inc()
+		}),
+		keyedworker.WithOnRemoveCallback[streamKey, Request](func(_ streamKey) {
+			d.activeWorkerCount.Add(-1)
+			metrics.NotificationWorkerGoroutinesGauge.Dec()
+		}),
+		keyedworker.WithLogger[streamKey, Request](log.WithName("pool")),
+	)
+
+	d.readiness.Add(1)
+	return d
+}
+
+func (d *Dispatcher) onRecordDrop(req Request) {
+	log := d.log.WithValues(
+		"plan", req.Payload.Plan.String(),
+		"sink", req.SinkName,
+		"sinkType", req.SinkType,
+		"event", req.Payload.Event,
+	)
+	log.Info("notification stream buffer full, dropping request")
+	metrics.NotificationDropTotal.WithLabelValues(req.SinkType, req.Payload.Event).Inc()
 }
 
 // NeedLeaderElection returns true — notifications should only fire from the leader.
@@ -169,55 +193,57 @@ func (d *Dispatcher) NeedLeaderElection() bool { return true }
 // interface rather than on *Dispatcher directly.
 func (d *Dispatcher) Notifier() Notifier { return d }
 
-// Start implements manager.Runnable. It spawns the overflow drainer, worker
-// goroutines, and blocks until ctx is cancelled. On shutdown it ensures all
-// in-flight and overflow items are delivered before returning.
-//
-// Shutdown sequence:
-//  1. close(d.done)         — Submit fast-path discards new requests
-//  2. d.shuttingDown = true — Submit overflow-path discards too
-//  3. Stop drainer, wait    — drainer returns unsent items to overflow
-//  4. Flush overflow → ch   — workers are still consuming from ch
-//  5. close(d.allFlushed)   — workers switch to drain-and-exit mode
-//  6. d.wg.Wait()           — all workers finish
-//
-// requestCh is never closed, so Submit can never panic with a
-// send-on-closed-channel even in a tiny race window.
+// Start implements manager.Runnable. It wires keyed per-stream workers and
+// blocks until ctx is cancelled. During shutdown, new submissions are rejected
+// and active stream workers are given a bounded time window to drain pending
+// per-stream items before Start returns.
 func (d *Dispatcher) Start(ctx context.Context) error {
-	d.log.Info("starting notification dispatcher", "workers", d.workers, "channelSize", d.channelSize)
-
-	// Start workers and overflow drainer.
-	go d.run(ctx)
-
-	d.log.V(1).Info("notification dispatcher running", "workers", d.workers, "channelSize", d.channelSize)
-	// Block until context is cancelled.
-	<-ctx.Done()
-
-	// --- Shutdown sequence ---
-	d.log.V(1).Info("notification dispatcher initiating shutdown")
-
-	// Signal shutdown to drainer and prevent Submit from accepting new requests.
-	close(d.done)
-
-	d.log.V(1).Info("notification dispatcher shutting down, waiting for flush",
-		"workers", d.workers,
-		"channelSize", len(d.requestCh),
-		"remainingOverflow", d.overflow.Len(),
+	d.log.Info("starting notification dispatcher",
+		"mode", "keyed-stream",
+		"perStreamBuffer", d.channelSize,
+		"workerIdleTTL", d.workerIdleTTL,
 	)
-	// At this point, workers goroutine might still performing flush from the remaining
-	// requests in the channel, once it dones, it will close the d.flushed channel
-	// to signal that all items have been flushed and processed regardless of the status.
-	<-d.flushed
+
+	d.pool.Register(ctx, d.workerFactory)
+	d.log.V(1).Info("notification dispatcher running", "mode", "keyed-stream")
+	d.readiness.Done()
+
+	<-ctx.Done()
+	d.log.V(1).Info("notification dispatcher initiating shutdown")
+	close(d.done)
+	d.pool.Stop()
+
+	deadline := time.NewTimer(defaultDrainTimeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
+waitLoop:
+	for {
+		if d.activeWorkerCount.Load() <= 0 {
+			d.log.V(1).Info("notification dispatcher workers drained")
+			break
+		}
+
+		select {
+		case <-deadline.C:
+			d.log.Info("notification dispatcher drain timeout reached; stopping with active workers", "activeWorkers", d.activeWorkerCount.Load())
+			break waitLoop
+		case <-ticker.C:
+		}
+	}
 
 	d.log.Info("notification dispatcher stopped")
 	return nil
 }
 
-// Submit enqueues a dispatch request. It never blocks the caller: if the buffered
-// channel has room the request goes directly; otherwise it is appended to the
-// internal overflow queue and the drainer will move it to the channel asynchronously.
+// Submit enqueues a dispatch request. It never blocks the caller. Requests are
+// routed into per-stream FIFO slots; if a per-stream buffer is full, the request
+// is dropped by the slot and counted in NotificationDropTotal.
 // After shutdown begins (d.done closed), requests are discarded with a metric.
 func (d *Dispatcher) Submit(req Request) {
+	d.readiness.Wait() // ensure Start has completed before accepting requests
+
 	log := d.log.WithValues(
 		"plan", req.Payload.Plan.String(),
 		"sink", req.SinkName,
@@ -234,140 +260,68 @@ func (d *Dispatcher) Submit(req Request) {
 	default:
 	}
 
-	// Try non-blocking send to the channel. No lock needed here because
-	// requestCh is never closed — the worst case is sending one extra item
-	// after shutdown, which workers will drain.
-	select {
-	case d.requestCh <- req:
-		return
-	default:
-	}
+	key := streamKeyFromRequest(req)
+	log.V(1).Info("enqueueing notification request", "stream", key)
+	d.pool.Deliver(key, req)
+}
 
-	if d.overflow.Len() >= d.maxOverflowSize {
-		log.Info("overflow queue full, dropping notification request")
-		metrics.NotificationDropTotal.WithLabelValues(req.SinkType, req.Payload.Event).Inc()
-		return
-	}
+func (d *Dispatcher) workerFactory(key streamKey, slot keyedworker.Slot[Request]) func(context.Context) {
+	return func(ctx context.Context) {
+		log := d.log.WithValues("stream", key)
+		log.V(1).Info("notification stream worker started")
 
-	log.V(1).Info("request channel full, adding notification request to overflow")
-	d.overflow.Append(req)
+		idleTimer := time.NewTimer(d.workerIdleTTL)
+		defer idleTimer.Stop()
 
-	// Wake the drainer (non-blocking signal).
-	select {
-	case d.drainSignal <- struct{}{}:
-	default: // already signaled
+		for {
+			select {
+			case <-ctx.Done():
+				d.drainSlot(slot)
+				log.V(1).Info("notification stream worker stopped")
+				return
+
+			case <-slot.C():
+				if !idleTimer.Stop() {
+					select {
+					case <-idleTimer.C:
+					default:
+					}
+				}
+				idleTimer.Reset(d.workerIdleTTL)
+
+				d.dispatch(ctx, slot.Recv())
+
+			case <-idleTimer.C:
+				for {
+					select {
+					case <-slot.C():
+						d.dispatch(ctx, slot.Recv())
+					default:
+						log.V(1).Info("notification stream worker reaped due to idle ttl")
+						return
+					}
+				}
+			}
+		}
 	}
 }
 
-// overflowDrainerLoop runs in a goroutine, waiting for signals to move items
-// from the overflow queue to the main channel.
-// Exits when drainStop is closed (shutdown).
-func (d *Dispatcher) overflowDrainerLoop() {
-	d.log.Info("notification overflow drainer started")
+func (d *Dispatcher) drainSlot(slot keyedworker.Slot[Request]) {
+	drainCtx, cancel := context.WithTimeout(context.Background(), defaultDrainTimeout)
+	defer cancel()
 
 	for {
+		if drainCtx.Err() != nil {
+			return
+		}
+
 		select {
-		case <-d.drainSignal:
-			if interrupted := d.drainOverflow(); interrupted {
-				d.log.V(1).Info("notification overflow drainer interrupted during shutdown, returning remaining items to overflow",
-					"remainingOverflow", d.overflow.Len())
-			}
-		case <-d.done:
-			d.log.Info("notification overflow drainer stopped")
-			close(d.drained)
+		case <-slot.C():
+			d.dispatch(drainCtx, slot.Recv())
+		default:
 			return
 		}
 	}
-}
-
-// drainOverflow moves all items currently in the overflow queue into the main channel.
-// It sends items to the channel in a select with d.drainStop so it can be
-// interrupted during shutdown — any unsent items are returned to the overflow
-// queue for the final flush in Start().
-func (d *Dispatcher) drainOverflow() bool {
-	var interrupted bool
-
-	d.overflow.Consume(func(ctx context.Context, req Request) bool {
-		select {
-		case d.requestCh <- req:
-			return true
-
-			// Context canceled after 5 seconds
-		case <-ctx.Done():
-			return false
-
-			// Dispatcher shutdown is signaled via d.done,
-			// but we also need to listen to ctx.Done() here to avoid blocking on send if the dispatcher is trying to shut down while we're draining overflow. This allows the drainer to exit promptly without getting stuck trying to send on a full channel during shutdown.
-		case <-d.done:
-			interrupted = true
-			return false
-		}
-	})
-
-	return interrupted
-}
-
-// run starts the worker goroutines responsible for processing dispatch requests
-// from the channel, including the overflow drainer.
-//
-// On shutdown, workers exit their loop when ctx is cancelled. After all workers
-// have stopped, run() waits for the drainer to finish and then drains both the
-// request channel and the overflow queue in a single goroutine. This avoids
-// duplicate dispatches that would occur if multiple workers each independently
-// drained the overflow, and ensures channel items are not lost.
-func (d *Dispatcher) run(ctx context.Context) {
-	go d.overflowDrainerLoop()
-
-	var activeWorkers sync.WaitGroup
-	for i := 0; i < d.workers; i++ {
-		activeWorkers.Add(1)
-		go func(workerID int) {
-			defer activeWorkers.Done()
-			d.log.Info("notification worker started", "workerID", workerID)
-
-			for {
-				select {
-				case req := <-d.requestCh:
-					d.dispatch(ctx, req)
-
-				case <-ctx.Done():
-					d.log.Info("notification worker stopped", "workerID", workerID)
-					return
-				}
-			}
-		}(i + 1)
-	}
-
-	activeWorkers.Wait()
-
-	// Wait for the drainer to finish and return any undrained items back to overflow.
-	<-d.drained
-
-	d.log.V(1).Info("draining remaining requests after shutdown",
-		"channelLen", len(d.requestCh),
-		"remainingOverflow", d.overflow.Len(),
-	)
-
-	dCtx, dCancel := context.WithTimeout(context.Background(), defaultDrainTimeout)
-	defer dCancel()
-
-	// Drain any items left in the request channel.
-drainChannel:
-	for {
-		select {
-		case req := <-d.requestCh:
-			d.dispatch(dCtx, req)
-		default:
-			break drainChannel
-		}
-	}
-
-	// Drain remaining overflow items.
-	d.overflow.Range(func(r Request) {
-		d.dispatch(dCtx, r)
-	})
-
-	close(d.flushed)
 }
 
 // dispatch processes a single DispatchRequest: resolves credentials, builds

--- a/internal/notification/dispatcher_test.go
+++ b/internal/notification/dispatcher_test.go
@@ -170,7 +170,7 @@ func TestDispatcher_SendsNotification(t *testing.T) {
 	}))
 
 	d := NewDispatcher(logger, client, registry, DispatcherConfig{
-		Workers: 1, ChannelSize: 8,
+		ChannelSize: 8,
 	})
 
 	startDispatcher(t, d)
@@ -197,7 +197,7 @@ func TestDispatcher_UnknownSinkType(t *testing.T) {
 	client := fake.NewClientBuilder().WithScheme(newTestScheme()).Build()
 
 	d := NewDispatcher(logr.Discard(), client, registry, DispatcherConfig{
-		Workers: 1, ChannelSize: 8,
+		ChannelSize: 8,
 	})
 
 	startDispatcher(t, d)
@@ -221,7 +221,7 @@ func TestDispatcher_SecretNotFound(t *testing.T) {
 	client := fake.NewClientBuilder().WithScheme(newTestScheme()).Build()
 
 	d := NewDispatcher(logr.Discard(), client, registry, DispatcherConfig{
-		Workers: 1, ChannelSize: 8,
+		ChannelSize: 8,
 	})
 
 	startDispatcher(t, d)
@@ -254,7 +254,7 @@ func TestDispatcher_SecretMissingConfigKey(t *testing.T) {
 		Build()
 
 	d := NewDispatcher(logr.Discard(), client, registry, DispatcherConfig{
-		Workers: 1, ChannelSize: 8,
+		ChannelSize: 8,
 	})
 
 	startDispatcher(t, d)
@@ -285,7 +285,7 @@ func TestDispatcher_SinkSendError(t *testing.T) {
 		Build()
 
 	d := NewDispatcher(logr.Discard(), client, registry, DispatcherConfig{
-		Workers: 1, ChannelSize: 8,
+		ChannelSize: 8,
 	})
 
 	startDispatcher(t, d)
@@ -316,7 +316,7 @@ func TestDispatcher_MultipleSinks(t *testing.T) {
 		Build()
 
 	d := NewDispatcher(logr.Discard(), client, registry, DispatcherConfig{
-		Workers: 2, ChannelSize: 16,
+		ChannelSize: 16,
 	})
 
 	startDispatcher(t, d)
@@ -341,7 +341,7 @@ func TestDispatcher_MultipleSinks(t *testing.T) {
 	assert.Len(t, telegramStub.getCalls(), 1)
 }
 
-func TestDispatcher_OverflowQueuesAllRequests(t *testing.T) {
+func TestDispatcher_PerStreamBufferDropsWhenSaturated(t *testing.T) {
 	// Slow sink to create backpressure.
 	stub := newStubSink("slack")
 	stub.sendFunc = func(_ context.Context, _ Payload, _ sinktypes.SendOptions) error {
@@ -357,9 +357,9 @@ func TestDispatcher_OverflowQueuesAllRequests(t *testing.T) {
 		WithObjects(secret).
 		Build()
 
-	// Small channel — overflow queue absorbs the excess.
+	// Small per-stream buffer — excess requests are dropped.
 	d := NewDispatcher(logr.Discard(), client, registry, DispatcherConfig{
-		Workers: 1, ChannelSize: 2,
+		ChannelSize: 2,
 	})
 
 	startDispatcher(t, d)
@@ -374,8 +374,8 @@ func TestDispatcher_OverflowQueuesAllRequests(t *testing.T) {
 		})
 	}
 
-	require.True(t, stub.waitCalls(total, 5*time.Second), "All requests should eventually be delivered")
-	assert.Equal(t, total, int(stub.callCount.Load()))
+	require.True(t, stub.waitCalls(2, 5*time.Second), "in-flight and buffered requests should be delivered")
+	assert.LessOrEqual(t, int(stub.callCount.Load()), 2)
 }
 
 func TestDispatcher_SubmitIsNonBlocking(t *testing.T) {
@@ -385,7 +385,7 @@ func TestDispatcher_SubmitIsNonBlocking(t *testing.T) {
 
 	client := fake.NewClientBuilder().WithScheme(newTestScheme()).Build()
 	d := NewDispatcher(logr.Discard(), client, registry, DispatcherConfig{
-		Workers: 1, ChannelSize: 1,
+		ChannelSize: 1,
 	})
 
 	startDispatcher(t, d)
@@ -424,7 +424,7 @@ func TestDispatcher_ContextCancellation(t *testing.T) {
 		Build()
 
 	d := NewDispatcher(logr.Discard(), client, registry, DispatcherConfig{
-		Workers: 1, ChannelSize: 8,
+		ChannelSize: 8,
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -448,22 +448,22 @@ func TestDispatcher_ContextCancellation(t *testing.T) {
 
 func TestDispatcher_Config(t *testing.T) {
 	d := NewDispatcher(logr.Discard(), nil, nil, DispatcherConfig{
-		Workers:         8,
 		ChannelSize:     512,
 		DispatchTimeout: 10 * time.Second,
+		WorkerIdleTTL:   45 * time.Second,
 	})
 
-	assert.Equal(t, 8, d.workers)
 	assert.Equal(t, 512, d.channelSize)
 	assert.Equal(t, 10*time.Second, d.dispatchTimeout)
+	assert.Equal(t, 45*time.Second, d.workerIdleTTL)
 }
 
 func TestDispatcher_ConfigZeroValuesUseDefaults(t *testing.T) {
 	d := NewDispatcher(logr.Discard(), nil, nil, DispatcherConfig{})
 
-	assert.Equal(t, defaultWorkers, d.workers)
 	assert.Equal(t, defaultChannelSize, d.channelSize)
 	assert.Equal(t, defaultDispatchTimeout, d.dispatchTimeout)
+	assert.Equal(t, defaultWorkerIdleTTL, d.workerIdleTTL)
 }
 
 func TestDispatcher_PassesPayloadToSink(t *testing.T) {
@@ -490,7 +490,7 @@ func TestDispatcher_PassesPayloadToSink(t *testing.T) {
 				Build()
 
 			d := NewDispatcher(logr.Discard(), client, registry, DispatcherConfig{
-				Workers: 1, ChannelSize: 8,
+				ChannelSize: 8,
 			})
 
 			startDispatcher(t, d)
@@ -537,7 +537,7 @@ func TestDispatcher_MalformedCustomTemplate(t *testing.T) {
 		Build()
 
 	d := NewDispatcher(logr.Discard(), client, registry, DispatcherConfig{
-		Workers: 1, ChannelSize: 8,
+		ChannelSize: 8,
 	})
 
 	startDispatcher(t, d)
@@ -604,7 +604,7 @@ func TestDispatcher_SlackJSONTemplate_EndToEnd(t *testing.T) {
 	registry := sinktypes.NewRegistry()
 	registry.Register(slacksink.New(NewTemplateEngine(logr.Discard()), slacksink.WithHTTPClient(&http.Client{Timeout: 5 * time.Second})))
 
-	d := NewDispatcher(logr.Discard(), client, registry, DispatcherConfig{Workers: 1, ChannelSize: 8})
+	d := NewDispatcher(logr.Discard(), client, registry, DispatcherConfig{ChannelSize: 8})
 	startDispatcher(t, d)
 
 	d.Submit(Request{
@@ -671,7 +671,7 @@ func TestDispatcher_SlackJSONTemplate_InvalidFallsBackToPreset(t *testing.T) {
 	registry := sinktypes.NewRegistry()
 	registry.Register(slacksink.New(NewTemplateEngine(logr.Discard()), slacksink.WithHTTPClient(&http.Client{Timeout: 5 * time.Second})))
 
-	d := NewDispatcher(logr.Discard(), client, registry, DispatcherConfig{Workers: 1, ChannelSize: 8})
+	d := NewDispatcher(logr.Discard(), client, registry, DispatcherConfig{ChannelSize: 8})
 	startDispatcher(t, d)
 
 	d.Submit(Request{
@@ -706,7 +706,7 @@ func TestDispatcher_SubmitAfterShutdown(t *testing.T) {
 	registry.Register(stub)
 	secret := sinkSecret("default", "slack-secret", []byte(`{"webhook_url":"url"}`))
 	client := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(secret).Build()
-	d := NewDispatcher(logr.Discard(), client, registry, DispatcherConfig{Workers: 1, ChannelSize: 2})
+	d := NewDispatcher(logr.Discard(), client, registry, DispatcherConfig{ChannelSize: 2})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	startDone := make(chan struct{})
@@ -740,7 +740,7 @@ func TestDispatcher_SubmitWithCancelledContext(t *testing.T) {
 
 	client := fake.NewClientBuilder().WithScheme(newTestScheme()).Build()
 	d := NewDispatcher(logr.Discard(), client, registry, DispatcherConfig{
-		Workers: 1, ChannelSize: 2,
+		ChannelSize: 2,
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -785,7 +785,7 @@ func TestDispatcher_SubmitWithAvailableChannelSpace(t *testing.T) {
 		Build()
 
 	d := NewDispatcher(logr.Discard(), client, registry, DispatcherConfig{
-		Workers: 1, ChannelSize: 10,
+		ChannelSize: 10,
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -824,7 +824,7 @@ func TestDispatcher_SubmitWithFullChannelAndDrain(t *testing.T) {
 
 	// 1 worker, channel size 1.
 	d := NewDispatcher(logr.Discard(), client, registry, DispatcherConfig{
-		Workers: 1, ChannelSize: 1,
+		ChannelSize: 1,
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -840,16 +840,18 @@ func TestDispatcher_SubmitWithFullChannelAndDrain(t *testing.T) {
 	// 2nd request: fills the channel (size 1)
 	d.Submit(Request{Payload: testPayload("req2"), SinkType: "slack", SecretRef: hibernatorv1alpha1.ObjectKeyReference{Name: "slack-secret"}})
 
-	// 3rd request: should go to overflow
+	// 3rd request: should be dropped when per-stream buffer is saturated
 	d.Submit(Request{Payload: testPayload("req3"), SinkType: "slack", SecretRef: hibernatorv1alpha1.ObjectKeyReference{Name: "slack-secret"}})
 
-	// Eventually all should be delivered
+	// Eventually at least the in-flight request is delivered. Depending on
+	// scheduling, the second request may be buffered and delivered too.
 	assert.Eventually(t, func() bool {
-		return stub.callCount.Load() == 3
+		c := stub.callCount.Load()
+		return c >= 1 && c <= 2
 	}, 2*time.Second, 10*time.Millisecond)
 }
 
-func TestDispatcher_FullProcessOverflowAndFlush(t *testing.T) {
+func TestDispatcher_FullProcessPerStreamBufferAndFlush(t *testing.T) {
 	stub := newStubSink("slack")
 
 	// Barrier: signals when the worker has picked up the first request and is blocked.
@@ -875,7 +877,6 @@ func TestDispatcher_FullProcessOverflowAndFlush(t *testing.T) {
 	}))
 
 	d := NewDispatcher(logger, client, registry, DispatcherConfig{
-		Workers:     1,
 		ChannelSize: 1,
 	})
 
@@ -897,31 +898,28 @@ func TestDispatcher_FullProcessOverflowAndFlush(t *testing.T) {
 	}
 
 	// Worker is blocked on <-block. Channel is empty.
-	// req2 fills the channel (size 1), req3 goes to overflow.
+	// req2 fills the per-stream buffer (size 1), req3 is dropped.
 	d.Submit(Request{Payload: testPayload("req2"), SinkType: "slack", SecretRef: hibernatorv1alpha1.ObjectKeyReference{Name: "slack-secret"}})
 	d.Submit(Request{Payload: testPayload("req3"), SinkType: "slack", SecretRef: hibernatorv1alpha1.ObjectKeyReference{Name: "slack-secret"}})
-
-	// Worker is still blocked — overflow must hold req3 before we release.
-	assert.Equal(t, 1, d.overflow.Len(), "req3 should be in overflow while worker is blocked")
 
 	// Unblock the worker so it can process all requests.
 	close(block)
 
-	// Wait for all 3 to be delivered deterministically.
-	if !stub.waitCalls(3, 2*time.Second) {
-		t.Fatal("timed out waiting for all 3 requests to be delivered")
+	// Wait for 2 to be delivered deterministically (1 in-flight + 1 buffered).
+	if !stub.waitCalls(2, 2*time.Second) {
+		t.Fatal("timed out waiting for buffered requests to be delivered")
 	}
 
 	// Cancel context to trigger shutdown.
 	cancel()
 	<-startDone
 
-	assert.Equal(t, int32(3), stub.callCount.Load())
+	assert.Equal(t, int32(2), stub.callCount.Load())
 }
 
-func TestDispatcher_ShutdownFlushesOverflowItems(t *testing.T) {
-	// Verify that items stuck in overflow and the channel at shutdown time are
-	// still delivered during the graceful-shutdown drain.
+func TestDispatcher_ShutdownFlushesBufferedItems(t *testing.T) {
+	// Verify that items in-flight and buffered in a single stream are delivered
+	// during graceful-shutdown drain.
 	stub := newStubSink("slack")
 
 	// Barrier: signals when the worker has picked up the first request and is blocked.
@@ -947,7 +945,7 @@ func TestDispatcher_ShutdownFlushesOverflowItems(t *testing.T) {
 	}))
 
 	d := NewDispatcher(logger, client, registry, DispatcherConfig{
-		Workers: 1, ChannelSize: 1,
+		ChannelSize: 1,
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -967,21 +965,18 @@ func TestDispatcher_ShutdownFlushesOverflowItems(t *testing.T) {
 		t.Fatal("timed out waiting for worker to pick up first request")
 	}
 
-	// Worker is blocked. Submit remaining: 1 fills channel, rest go to overflow.
+	// Worker is blocked. Submit remaining: 1 fills buffer, rest are dropped.
 	for i := 1; i < total; i++ {
-		d.Submit(Request{Payload: testPayload("req"), SinkType: "slack", SinkName: fmt.Sprintf("slack-%d", i), SecretRef: hibernatorv1alpha1.ObjectKeyReference{Name: "slack-secret"}})
+		d.Submit(Request{Payload: testPayload("req"), SinkType: "slack", SinkName: "slack-0", SecretRef: hibernatorv1alpha1.ObjectKeyReference{Name: "slack-secret"}})
 	}
-
-	// Worker is still blocked — overflow must hold the excess before we release.
-	assert.GreaterOrEqual(t, d.overflow.Len(), 1, "some items should be in overflow while worker is blocked")
 
 	// Unblock the worker and cancel immediately — forces shutdown with pending items.
 	close(block)
 	cancel()
 	<-startDone
 
-	// All items must be delivered during graceful shutdown.
-	assert.Equal(t, int32(total), stub.callCount.Load(), "All items should be delivered during graceful shutdown")
+	// Exactly in-flight + one buffered should be delivered during graceful shutdown.
+	assert.Equal(t, int32(2), stub.callCount.Load(), "in-flight and buffered items should be delivered during graceful shutdown")
 }
 
 func TestDispatcher_ConcurrentSubmitDuringShutdown(t *testing.T) {
@@ -998,7 +993,7 @@ func TestDispatcher_ConcurrentSubmitDuringShutdown(t *testing.T) {
 		Build()
 
 	d := NewDispatcher(logr.Discard(), client, registry, DispatcherConfig{
-		Workers: 2, ChannelSize: 4,
+		ChannelSize: 4,
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1044,8 +1039,8 @@ func TestDispatcher_ConcurrentSubmitDuringShutdown(t *testing.T) {
 	assert.GreaterOrEqual(t, stub.callCount.Load(), int32(0))
 }
 
-func TestDispatcher_OverflowMaxSizeDropsExcess(t *testing.T) {
-	// When overflow queue reaches maxOverflowSize, excess requests are dropped.
+func TestDispatcher_PerStreamBufferDropsExcess(t *testing.T) {
+	// When per-stream buffer is full, excess requests are dropped.
 	stub := newStubSink("slack")
 	// Block all sends so nothing gets consumed.
 	stub.sendFunc = func(ctx context.Context, payload Payload, opts sinktypes.SendOptions) error {
@@ -1057,11 +1052,8 @@ func TestDispatcher_OverflowMaxSizeDropsExcess(t *testing.T) {
 
 	client := fake.NewClientBuilder().WithScheme(newTestScheme()).Build()
 
-	const maxOverflow = 3
 	d := NewDispatcher(logr.Discard(), client, registry, DispatcherConfig{
-		Workers:         1,
-		ChannelSize:     1,
-		MaxOverflowSize: maxOverflow,
+		ChannelSize: 1,
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1072,17 +1064,15 @@ func TestDispatcher_OverflowMaxSizeDropsExcess(t *testing.T) {
 	}()
 	time.Sleep(50 * time.Millisecond)
 
-	// Fill: 1 in worker (blocked), 1 in channel, maxOverflow in overflow = maxOverflow+2.
-	// Any additional should be dropped.
-	for i := 0; i < maxOverflow+10; i++ {
+	// Fill: 1 in worker (blocked), 1 in per-stream buffer; additional should be dropped.
+	for i := 0; i < 20; i++ {
 		d.Submit(Request{Payload: testPayload("flood"), SinkType: "slack", SecretRef: hibernatorv1alpha1.ObjectKeyReference{Name: "slack-secret"}})
 	}
 
-	overflowLen := d.overflow.Len()
-	assert.LessOrEqual(t, overflowLen, maxOverflow, "Overflow should not exceed max size")
-
 	cancel()
 	<-startDone
+
+	assert.LessOrEqual(t, stub.callCount.Load(), int32(2), "only in-flight and one buffered request can be observed")
 }
 
 func TestSinkStatusKey_CanonicalFormat(t *testing.T) {

--- a/internal/notification/dispatcher_test.go
+++ b/internal/notification/dispatcher_test.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -26,6 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	hibernatorv1alpha1 "github.com/ardikabs/hibernator/api/v1alpha1"
@@ -1078,4 +1080,248 @@ func TestDispatcher_PerStreamBufferDropsExcess(t *testing.T) {
 func TestSinkStatusKey_CanonicalFormat(t *testing.T) {
 	key := SinkStatusKey("slack-prod", "default", "my-plan", "cycle-001", "shutdown")
 	require.Equal(t, "slack-prod|default/my-plan|cycle-001|shutdown", key)
+}
+
+// TestDispatcher_SameStreamOrdering_DeterministicFIFO verifies that events for the
+// same stream (same plan+cycle+notification+sink+operation) are processed in strict
+// FIFO order, eliminating the race condition between ExecutionProgress and Success.
+func TestDispatcher_SameStreamOrdering_DeterministicFIFO(t *testing.T) {
+	stub := newStubSink("slack")
+	// Slow sink to create backpressure and ensure events queue up
+	stub.sendFunc = func(_ context.Context, _ Payload, _ sinktypes.SendOptions) error {
+		time.Sleep(50 * time.Millisecond)
+		return nil
+	}
+	registry := sinktypes.NewRegistry()
+	registry.Register(stub)
+
+	secret := sinkSecret("default", "slack-secret", []byte(`{"webhook_url":"url"}`))
+	client := fake.NewClientBuilder().
+		WithScheme(newTestScheme()).
+		WithObjects(secret).
+		Build()
+
+	d := NewDispatcher(logr.Discard(), client, registry, DispatcherConfig{
+		ChannelSize: 10, // Buffer multiple events
+	})
+
+	startDispatcher(t, d)
+
+	// Submit 5 events in specific order to the same stream
+	events := []string{"Start", "ExecutionProgress", "ExecutionProgress", "ExecutionProgress", "Success"}
+	for i, event := range events {
+		payload := testPayload(event)
+		payload.CycleID = "cycle-001" // Same cycle
+		d.Submit(Request{
+			Payload:         payload,
+			SinkName:        "slack-sink",
+			SinkType:        "slack",
+			SecretRef:       hibernatorv1alpha1.ObjectKeyReference{Name: "slack-secret"},
+			NotificationRef: types.NamespacedName{Name: "notif-1", Namespace: "default"},
+		})
+		t.Logf("Submitted event %d: %s", i, event)
+	}
+
+	// Wait for all events to be delivered
+	require.True(t, stub.waitCalls(len(events), 5*time.Second), "All events should be delivered")
+
+	// Verify FIFO ordering
+	calls := stub.getCalls()
+	require.Len(t, calls, len(events))
+
+	for i, expectedEvent := range events {
+		actualEvent := calls[i].Payload.Event
+		assert.Equal(t, expectedEvent, actualEvent, "Event at position %d should match (FIFO ordering)", i)
+	}
+
+	t.Log("FIFO ordering verified: events processed in submission order")
+}
+
+// TestDispatcher_SameStreamOrdering_ExecutionProgressBeforeSuccess specifically
+// tests the reported race condition scenario where ExecutionProgress and Success
+// events could be reordered. With keyed workers, they must be deterministic.
+func TestDispatcher_SameStreamOrdering_ExecutionProgressBeforeSuccess(t *testing.T) {
+	stub := newStubSink("slack")
+	// Variable delay to simulate network jitter
+	var rngMu sync.Mutex
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	stub.sendFunc = func(_ context.Context, _ Payload, _ sinktypes.SendOptions) error {
+		rngMu.Lock()
+		delay := time.Duration(10+rng.Intn(50)) * time.Millisecond
+		rngMu.Unlock()
+		time.Sleep(delay)
+		return nil
+	}
+	registry := sinktypes.NewRegistry()
+	registry.Register(stub)
+
+	secret := sinkSecret("default", "slack-secret", []byte(`{"webhook_url":"url"}`))
+	client := fake.NewClientBuilder().
+		WithScheme(newTestScheme()).
+		WithObjects(secret).
+		Build()
+
+	d := NewDispatcher(logr.Discard(), client, registry, DispatcherConfig{
+		ChannelSize: 5,
+	})
+
+	startDispatcher(t, d)
+
+	// Run multiple iterations to verify determinism
+	for iteration := 0; iteration < 10; iteration++ {
+		// Rapid-fire ExecutionProgress then Success to same stream
+		for i := 0; i < 3; i++ {
+			payload := testPayload("ExecutionProgress")
+			payload.CycleID = fmt.Sprintf("cycle-%d", iteration)
+			d.Submit(Request{
+				Payload:         payload,
+				SinkName:        "slack-sink",
+				SinkType:        "slack",
+				SecretRef:       hibernatorv1alpha1.ObjectKeyReference{Name: "slack-secret"},
+				NotificationRef: types.NamespacedName{Name: "notif-1", Namespace: "default"},
+			})
+		}
+
+		payload := testPayload("Success")
+		payload.CycleID = fmt.Sprintf("cycle-%d", iteration)
+		d.Submit(Request{
+			Payload:         payload,
+			SinkName:        "slack-sink",
+			SinkType:        "slack",
+			SecretRef:       hibernatorv1alpha1.ObjectKeyReference{Name: "slack-secret"},
+			NotificationRef: types.NamespacedName{Name: "notif-1", Namespace: "default"},
+		})
+
+		// Wait for this iteration's events
+		require.True(t, stub.waitCalls((iteration+1)*4, 5*time.Second), "Iteration %d: events should be delivered", iteration)
+
+		// Verify ordering for this cycle
+		calls := stub.getCalls()
+		cycleCalls := filterCallsByCycle(calls, fmt.Sprintf("cycle-%d", iteration))
+		require.Len(t, cycleCalls, 4, "Iteration %d: should have 4 events", iteration)
+
+		// First 3 should be ExecutionProgress, last should be Success
+		for i := 0; i < 3; i++ {
+			assert.Equal(t, "ExecutionProgress", cycleCalls[i].Payload.Event,
+				"Iteration %d: event %d should be ExecutionProgress", iteration, i)
+		}
+		assert.Equal(t, "Success", cycleCalls[3].Payload.Event,
+			"Iteration %d: event 3 should be Success", iteration)
+	}
+
+	t.Log("Deterministic ordering verified across 10 iterations")
+}
+
+// TestDispatcher_CrossStreamParallelism_DifferentStreamsConcurrent verifies that
+// different streams are processed concurrently while maintaining FIFO within each stream.
+func TestDispatcher_CrossStreamParallelism_DifferentStreamsConcurrent(t *testing.T) {
+	stub := newStubSink("slack")
+
+	// Use a latch pattern: first event from each stream signals readiness
+	stream1Started := make(chan struct{})
+	stream2Started := make(chan struct{})
+	barrier := make(chan struct{})
+
+	stub.sendFunc = func(_ context.Context, payload Payload, _ sinktypes.SendOptions) error {
+		// Signal stream start on first event
+		if payload.Event == "A1" {
+			close(stream1Started)
+		} else if payload.Event == "B1" {
+			close(stream2Started)
+		}
+		// Wait for barrier to ensure both streams are active concurrently
+		<-barrier
+		return nil
+	}
+
+	registry := sinktypes.NewRegistry()
+	registry.Register(stub)
+
+	secret := sinkSecret("default", "slack-secret", []byte(`{"webhook_url":"url"}`))
+	client := fake.NewClientBuilder().
+		WithScheme(newTestScheme()).
+		WithObjects(secret).
+		Build()
+
+	d := NewDispatcher(logr.Discard(), client, registry, DispatcherConfig{
+		ChannelSize: 10,
+	})
+
+	startDispatcher(t, d)
+
+	// Submit events to two different streams
+	// Stream 1: A1, A2
+	// Stream 2: B1, B2
+	for i := 1; i <= 2; i++ {
+		payload1 := testPayload(fmt.Sprintf("A%d", i))
+		payload1.CycleID = "stream-1"
+		d.Submit(Request{
+			Payload:         payload1,
+			SinkName:        "slack-sink",
+			SinkType:        "slack",
+			SecretRef:       hibernatorv1alpha1.ObjectKeyReference{Name: "slack-secret"},
+			NotificationRef: types.NamespacedName{Name: "notif-1", Namespace: "default"},
+		})
+
+		payload2 := testPayload(fmt.Sprintf("B%d", i))
+		payload2.CycleID = "stream-2"
+		d.Submit(Request{
+			Payload:         payload2,
+			SinkName:        "slack-sink",
+			SinkType:        "slack",
+			SecretRef:       hibernatorv1alpha1.ObjectKeyReference{Name: "slack-secret"},
+			NotificationRef: types.NamespacedName{Name: "notif-2", Namespace: "default"},
+		})
+	}
+
+	// Wait for both streams to start processing (shows parallelism)
+	select {
+	case <-stream1Started:
+		t.Log("Stream 1 started")
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stream 1 did not start")
+	}
+
+	select {
+	case <-stream2Started:
+		t.Log("Stream 2 started")
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stream 2 did not start")
+	}
+
+	// Both streams have started - release the barrier
+	close(barrier)
+
+	// Wait for all events
+	require.True(t, stub.waitCalls(4, 5*time.Second), "All events should be delivered")
+
+	// Verify FIFO ordering within each stream from the recorded calls
+	calls := stub.getCalls()
+
+	var stream1Order, stream2Order []string
+	for _, call := range calls {
+		if call.Payload.CycleID == "stream-1" {
+			stream1Order = append(stream1Order, call.Payload.Event)
+		} else {
+			stream2Order = append(stream2Order, call.Payload.Event)
+		}
+	}
+
+	require.Len(t, stream1Order, 2, "Stream 1 should have 2 events")
+	require.Len(t, stream2Order, 2, "Stream 2 should have 2 events")
+
+	assert.Equal(t, []string{"A1", "A2"}, stream1Order, "Stream 1 should be FIFO")
+	assert.Equal(t, []string{"B1", "B2"}, stream2Order, "Stream 2 should be FIFO")
+
+	t.Log("Cross-stream parallelism and FIFO ordering verified")
+}
+
+func filterCallsByCycle(calls []stubSendCall, cycleID string) []stubSendCall {
+	var filtered []stubSendCall
+	for _, call := range calls {
+		if call.Payload.CycleID == cycleID {
+			filtered = append(filtered, call)
+		}
+	}
+	return filtered
 }

--- a/pkg/keyedworker/handler.go
+++ b/pkg/keyedworker/handler.go
@@ -12,9 +12,9 @@ import (
 	"time"
 )
 
-// RunnerFactory wraps a stateless per-value handler into the Pool factory
-// signature. The returned factory is suitable for passing directly to Pool.Register
-// when the consumer does not need to maintain any state across deliveries.
+// RunnerFactory wraps a stateless per-value handler into a workerFactory
+// suitable for passing directly to Pool.Register when the consumer does not need
+// to maintain any state across deliveries.
 //
 // # When to use RunnerFactory
 //
@@ -27,12 +27,12 @@ import (
 //
 // If the caller can manage its own serialization — maintaining a dedicated
 // long-lived goroutine, an event loop, or a structured receive/send discipline —
-// it should supply a custom factory directly to Pool.Register and skip
+// it should supply a custom workerFactory directly to Pool.Register and skip
 // RunnerFactory entirely. The Coordinator is a canonical example: it owns an
 // explicit actor model with a select loop and state machine, so it drives the
 // slot directly and does not need RunnerFactory's idle-reap abstraction.
 //
-// The goroutine body it produces drives the slot via an idle timer loop:
+// The goroutine body produced by the workerFactory drives the slot via an idle timer loop:
 //   - On each slot signal the handler is called with the latest value.
 //   - The idle timer is reset on each delivery.
 //   - When idleTTL elapses with no delivery the goroutine returns, allowing

--- a/pkg/keyedworker/pool.go
+++ b/pkg/keyedworker/pool.go
@@ -20,21 +20,33 @@ Licensed under the Apache License, Version 2.0.
 //   - Clean removal: Remove cancels the per-key goroutine and drains the slot,
 //     freeing memory when a resource is deleted.
 //
+// # Two Factories: Slot vs Worker
+//
+// The Pool uses two distinct factories:
+//
+//   - slotFactory (via WithSlotFactory option): Creates per-key Slots that buffer
+//     values. Defaults to FIFOSlot. Must be provided at Pool construction time.
+//
+//   - workerFactory (via Register method): Creates per-key worker goroutine bodies.
+//     Must be provided at runtime when the context becomes available.
+//
+// This separation allows Deliver() calls to buffer values before Register() is called,
+// supporting decoupled initialization patterns common in controller-runtime Runnables.
+//
 // # Bring Your Own Slot
 //
-// The Pool is agnostic to delivery semantics. Callers choose a Slot implementation
-// via WithSlotFactory:
+// Callers choose a Slot implementation via WithSlotFactory:
 //
 //   - FIFOSlot: backed by a buffered channel. Every update is preserved in FIFO
 //     order. Use for consumers where no update can be dropped (e.g. status writers).
 //
-//   - LatestWinsSlot: backed by conflate.Pipeline. Concurrent sends coalesce into
-//     the latest value. Use for consumers where only the freshest snapshot matters
+//   - LatestWinsSlot: backed by a conflate.Pipeline. Concurrent sends coalesce into
+//     a single latest-value notification. Use for consumers where only the freshest snapshot matters
 //     and intermediate updates are safe to discard (e.g. plan actor workers).
 //
-// # Bring Your Own Run Body
+// # Bring Your Own Worker Body
 //
-// The consumer controls what the goroutine does by providing a factory to Start:
+// The consumer controls what the goroutine does by providing a workerFactory to Register:
 //
 //	pool.Register(ctx, func(key K, slot Slot[V]) func(context.Context) {
 //	    // Return the goroutine body. The Pool owns the goroutine's lifecycle.
@@ -43,18 +55,26 @@ Licensed under the Apache License, Version 2.0.
 //	    }
 //	})
 //
-// For the common stateless-callback pattern, HandlerRunFactory is a convenience
+// The workerFactory is stored atomically to ensure safe concurrent access with Deliver.
+// For the common stateless-callback pattern, RunnerFactory is a convenience
 // helper that wraps a per-value handler and an idle TTL into the factory signature.
 package keyedworker
 
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 
 	"github.com/go-logr/logr"
 )
 
 const defaultFIFOBufSize = 100
+
+// workerFactoryFunc wraps the user-supplied worker factory for atomic storage.
+// This enables safe concurrent access between Register (write) and Deliver (read).
+type workerFactoryFunc[K comparable, V any] struct {
+	fn func(K, Slot[V]) func(context.Context)
+}
 
 // Pool manages a set of per-key worker goroutines.
 // The zero value is not usable; use New to create instances.
@@ -62,8 +82,9 @@ type Pool[K comparable, V any] struct {
 	mu      sync.RWMutex
 	entries map[K]*entry[V]
 
-	// factory is the goroutine-body factory registered at Start.
-	factory func(K, Slot[V]) func(context.Context)
+	// workerFactory represents the user-supplied factory for per-key goroutine bodies. It is nil until Register is called.
+	// Use atomic operations to access.
+	workerFactory atomic.Pointer[workerFactoryFunc[K, V]]
 
 	// slotFactory creates a fresh Slot for each new entry.
 	slotFactory func() Slot[V]
@@ -130,7 +151,11 @@ func WithAutoRemoveOnIdle[K comparable, V any]() Option[K, V] {
 	return func(p *Pool[K, V]) { p.autoRemoveOnIdle = true }
 }
 
-// New creates a new Pool. The pool is not active until Start is called.
+// New creates a new Pool with the configured slotFactory.
+//
+// The pool is not active until Register is called with the workerFactory.
+// Deliver can be called before Register; values will buffer in the slot
+// and workers will activate once Register provides the workerFactory.
 func New[K comparable, V any](opts ...Option[K, V]) *Pool[K, V] {
 	p := &Pool[K, V]{
 		entries: make(map[K]*entry[V]),
@@ -145,26 +170,27 @@ func New[K comparable, V any](opts ...Option[K, V]) *Pool[K, V] {
 	return p
 }
 
-// Register arms the pool with a goroutine-body factory and parent context, then
+// Register arms the pool with a workerFactory and parent context, then
 // activates workers for any keys whose slots already have pending items (from
-// pre-Register Deliver calls). Must be called exactly once before Deliver can
-// dispatch work.
+// pre-Register Deliver calls). Must be called exactly once before workers can
+// start processing.
 //
-// Register is non-blocking — it returns immediately after arming the factory
+// Register stores the workerFactory atomically to ensure safe concurrent access
+// with Deliver. It is non-blocking — it returns immediately after arming the factory
 // and flushing pre-buffered items. The caller is responsible for blocking until
 // the desired lifetime is over (e.g. <-ctx.Done()), then calling Stop.
 //
-// factory receives a key and the key's Slot and must return a func(context.Context)
+// workerFactory receives a key and the key's Slot and must return a func(context.Context)
 // that is the goroutine body. The Pool owns the goroutine's lifecycle — the returned
 // func must respect ctx cancellation and return when done.
-func (p *Pool[K, V]) Register(ctx context.Context, factory func(K, Slot[V]) func(context.Context)) {
+func (p *Pool[K, V]) Register(ctx context.Context, workerFactoryFn func(K, Slot[V]) func(context.Context)) {
 	p.ctxMu.Lock()
 	p.parentCtx, p.parentCancel = context.WithCancel(ctx)
 	p.ctxMu.Unlock()
 
-	p.factory = factory
+	p.workerFactory.Store(&workerFactoryFunc[K, V]{fn: workerFactoryFn})
 
-	// Activate workers for any items that arrived before Start was called.
+	// Activate workers for any items that arrived before Register was called.
 	p.mu.RLock()
 	for key, e := range p.entries {
 		if e.slot.Len() > 0 {
@@ -176,12 +202,12 @@ func (p *Pool[K, V]) Register(ctx context.Context, factory func(K, Slot[V]) func
 
 // Deliver routes value to the per-key slot and ensures the worker goroutine is running.
 // Never blocks: if the slot is full (for FIFO) the value is dropped at the slot level.
-// Safe to call before Start; pending items are processed once Start registers the factory.
+// Safe to call before Register; pending items are processed once Register provides the workerFactory.
 func (p *Pool[K, V]) Deliver(key K, value V) {
 	e := p.getOrCreate(key)
 	e.slot.Send(value)
 
-	if p.factory != nil {
+	if p.workerFactory.Load() != nil {
 		p.ensureRunning(key, e)
 	}
 }
@@ -286,7 +312,7 @@ func (p *Pool[K, V]) ensureRunning(key K, e *entry[V]) {
 	go p.runEntry(ctx, key, e)
 }
 
-// runEntry launches the user-supplied goroutine body. It fires the onSpawn hook
+// runEntry launches the user-supplied worker goroutine body. It fires the onSpawn hook
 // before calling the body, and the onRemove hook plus idle-restart / auto-remove
 // logic in its defer.
 func (p *Pool[K, V]) runEntry(ctx context.Context, key K, e *entry[V]) {
@@ -294,7 +320,15 @@ func (p *Pool[K, V]) runEntry(ctx context.Context, key K, e *entry[V]) {
 		p.onSpawn(key)
 	}
 
-	fn := p.factory(key, e.slot)
+	// Load the workerFactory atomically. This is safe because Register stores it
+	// atomically before any workers can start (ensureRunning checks parentCtx first).
+	wf := p.workerFactory.Load()
+	if wf == nil {
+		// No workerFactory registered yet; this shouldn't happen because ensureRunning
+		// checks parentCtx, but be defensive.
+		return
+	}
+	fn := wf.fn(key, e.slot)
 
 	defer func() {
 		e.mu.Lock()

--- a/pkg/keyedworker/pool_test.go
+++ b/pkg/keyedworker/pool_test.go
@@ -221,6 +221,43 @@ func TestPool_Deliver_FIFOBufferFull_DropsUpdate(t *testing.T) {
 	// No assertion needed beyond "no panic or deadlock".
 }
 
+func TestPool_Deliver_FIFOBufferFull_OnDropCallbackCalled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const bufSize = 1
+	blocker := make(chan struct{})
+	dropped := make(chan int, 8)
+
+	p := New(WithSlotFactory[string](FIFOSlotWithOnDrop[int](bufSize, func(v int) {
+		dropped <- v
+	})))
+	p.Register(ctx, RunnerFactory[string](testIdleTTL,
+		func(_ context.Context, _ int) error {
+			<-blocker
+			return nil
+		},
+		nil,
+	))
+
+	// First request is consumed by worker and blocks.
+	p.Deliver("k", 1)
+	time.Sleep(20 * time.Millisecond)
+
+	// Second fills buffer, third is dropped and must trigger callback.
+	p.Deliver("k", 2)
+	p.Deliver("k", 3)
+
+	select {
+	case v := <-dropped:
+		assert.Equal(t, 3, v)
+	case <-time.After(time.Second):
+		t.Fatal("expected onDrop callback to be called")
+	}
+
+	close(blocker)
+}
+
 // ---------------------------------------------------------------------------
 // LatestWinsSlot — coalescing behaviour
 // ---------------------------------------------------------------------------

--- a/pkg/keyedworker/slot.go
+++ b/pkg/keyedworker/slot.go
@@ -43,15 +43,23 @@ type Slot[V any] interface {
 
 // FIFOSlot returns a SlotFactory that creates FIFO-ordered slots backed by a
 // buffered channel of size bufSize. When the buffer is full, Send drops the value
-// (non-blocking). Every value sent is preserved and delivered in order.
+// (non-blocking). Every accepted value is preserved and delivered in order.
 //
 // Use FIFOSlot for consumers where every update is meaningful and must not be
 // discarded (e.g. status writers that serialise K8s write calls).
 func FIFOSlot[V any](bufSize int) func() Slot[V] {
+	return FIFOSlotWithOnDrop[V](bufSize, nil)
+}
+
+// FIFOSlotWithOnDrop is like FIFOSlot, but invokes onDrop when a value is
+// dropped because the FIFO buffer is full. Pass nil for onDrop to disable drop
+// callbacks.
+func FIFOSlotWithOnDrop[V any](bufSize int, onDrop func(V)) func() Slot[V] {
 	return func() Slot[V] {
 		s := &fifoSlot[V]{
 			queue:  make(chan V, bufSize),
 			signal: make(chan struct{}, 1),
+			onDrop: onDrop,
 		}
 		return s
 	}
@@ -60,12 +68,16 @@ func FIFOSlot[V any](bufSize int) func() Slot[V] {
 type fifoSlot[V any] struct {
 	queue  chan V
 	signal chan struct{}
+	onDrop func(V)
 }
 
 func (s *fifoSlot[V]) Send(v V) {
 	select {
 	case s.queue <- v:
 	default:
+		if s.onDrop != nil {
+			s.onDrop(v)
+		}
 		// Buffer full — drop. Pool logs this at the Deliver call site.
 		return
 	}

--- a/test/e2e/tests/notification.go
+++ b/test/e2e/tests/notification.go
@@ -8,6 +8,7 @@ Licensed under the Apache License, Version 2.0.
 package tests
 
 import (
+	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -939,5 +940,142 @@ var _ = Describe("Notification E2E", func() {
 			return false
 		}, testutil.DefaultTimeout, testutil.DefaultInterval).
 			Should(BeTrue(), "expected ExecutionProgress notification with state=Completed for 'database'")
+	})
+
+	It("EventOrdering: should deliver ExecutionProgress before Success for the same cycle", func() {
+		const planLabel = "notif-ordering-test"
+
+		By("Creating HibernateNotification subscribed to ExecutionProgress and Success events")
+		notification = &hibernatorv1alpha1.HibernateNotification{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "notif-ordering",
+				Namespace: testNamespace,
+			},
+			Spec: hibernatorv1alpha1.HibernateNotificationSpec{
+				Selector: metav1.LabelSelector{
+					MatchLabels: map[string]string{"test-scenario": planLabel},
+				},
+				OnEvents: []hibernatorv1alpha1.NotificationEvent{
+					hibernatorv1alpha1.EventStart,
+					hibernatorv1alpha1.EventExecutionProgress,
+					hibernatorv1alpha1.EventSuccess,
+				},
+				Sinks: []hibernatorv1alpha1.NotificationSink{
+					{
+						Name:      "fake-webhook",
+						Type:      hibernatorv1alpha1.NotificationSinkType(fakenotif.SinkType),
+						SecretRef: hibernatorv1alpha1.ObjectKeyReference{Name: sinkSecret.Name, Key: ptr.To("config")},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, notification)).To(Succeed())
+
+		// Start in on-hours so the plan initialises to Active first.
+		fakeClock.SetTime(time.Date(2026, 6, 15, 8, 0, 0, 0, time.UTC))
+
+		By("Creating HibernatePlan with labels matching the notification selector")
+		plan, _ = testutil.NewHibernatePlanBuilder("notif-ordering", testNamespace).
+			WithLabels(map[string]string{"test-scenario": planLabel}).
+			WithSchedule("20:00", "06:00", "MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN").
+			WithExecutionStrategy(hibernatorv1alpha1.ExecutionStrategy{
+				Type: hibernatorv1alpha1.StrategySequential,
+			}).
+			WithTarget(hibernatorv1alpha1.Target{
+				Name: "database",
+				Type: "noop",
+				ConnectorRef: hibernatorv1alpha1.ConnectorRef{
+					Kind: "CloudProvider",
+					Name: "notif-aws",
+				},
+			}).
+			Build()
+		Expect(k8sClient.Create(ctx, plan)).To(Succeed())
+
+		By("Verifying plan initializes to Active phase")
+		testutil.EventuallyPhase(ctx, k8sClient, plan, hibernatorv1alpha1.PhaseActive)
+
+		// ------------------------------------------------------------------ Trigger hibernation
+		By("Advancing clock to off-hours to trigger hibernation")
+		fakeClock.SetTime(time.Date(2026, 6, 15, 20, 1, 10, 0, time.UTC))
+		testutil.TriggerReconcile(ctx, k8sClient, plan)
+
+		By("Verifying plan transitions to Hibernating")
+		testutil.EventuallyPhase(ctx, k8sClient, plan, hibernatorv1alpha1.PhaseHibernating)
+		hibernatingJob := testutil.EventuallyJobCreated(ctx, k8sClient, testNamespace, plan.Name, hibernatorv1alpha1.OperationHibernate, "database")
+		testutil.SimulateJobRunning(ctx, k8sClient, hibernatingJob, fakeClock.Now())
+		testutil.TriggerReconcile(ctx, k8sClient, plan)
+
+		// Wait for ExecutionProgress to be delivered first
+		By("Waiting for ExecutionProgress notification")
+		Eventually(func() bool {
+			for _, r := range fakeNotifSink.Records() {
+				if r.Payload.Event == "ExecutionProgress" &&
+					r.Payload.TargetExecution != nil &&
+					r.Payload.TargetExecution.Name == "database" {
+					return true
+				}
+			}
+			return false
+		}, testutil.DefaultTimeout, testutil.DefaultInterval).
+			Should(BeTrue(), "expected ExecutionProgress notification")
+
+		// Get the CycleID from the first ExecutionProgress notification
+		var cycleID string
+		for _, r := range fakeNotifSink.Records() {
+			if r.Payload.Event == "ExecutionProgress" {
+				cycleID = r.Payload.CycleID
+				break
+			}
+		}
+		Expect(cycleID).NotTo(BeEmpty(), "CycleID should be set in ExecutionProgress notification")
+
+		By("Simulating hibernation Job success")
+		hibernationJob := testutil.EventuallyJobCreated(ctx, k8sClient, testNamespace, plan.Name,
+			hibernatorv1alpha1.OperationHibernate, "database")
+		testutil.SimulateJobSuccess(ctx, k8sClient, hibernationJob, fakeClock.Now())
+
+		By("Verifying plan transitions to Hibernated")
+		testutil.EventuallyPhase(ctx, k8sClient, plan, hibernatorv1alpha1.PhaseHibernated)
+
+		By("Waiting for Success notification")
+		Eventually(fakeNotifSink.Len, testutil.DefaultTimeout, testutil.DefaultInterval).
+			Should(BeNumerically(">=", 2), "expected both ExecutionProgress and Success notifications")
+
+		// Verify deterministic ordering: all ExecutionProgress events for this cycle
+		// should be delivered before the Success event
+		By("Verifying ExecutionProgress was delivered before Success for the same cycle")
+		records := fakeNotifSink.Records()
+
+		var executionProgressIndices []int
+		var successIndex int
+		successFound := false
+
+		for i, r := range records {
+			if r.Payload.CycleID == cycleID {
+				switch r.Payload.Event {
+				case "ExecutionProgress":
+					executionProgressIndices = append(executionProgressIndices, i)
+				case "Success":
+					if !successFound {
+						successIndex = i
+						successFound = true
+					}
+				}
+			}
+		}
+
+		Expect(successFound).To(BeTrue(), "Success notification should be found for cycle %s", cycleID)
+		Expect(executionProgressIndices).NotTo(BeEmpty(), "At least one ExecutionProgress should be found for cycle %s", cycleID)
+
+		// All ExecutionProgress events should come before Success
+		for _, epIndex := range executionProgressIndices {
+			Expect(epIndex).To(BeNumerically("<", successIndex),
+				"ExecutionProgress (index %d) should be delivered before Success (index %d) for cycle %s",
+				epIndex, successIndex, cycleID)
+		}
+
+		By(fmt.Sprintf("Verified deterministic ordering: %d ExecutionProgress events delivered before Success for cycle %s",
+			len(executionProgressIndices), cycleID))
 	})
 })


### PR DESCRIPTION
Replaces the fixed global worker model with adaptive per-stream keyed workers to guarantee deterministic ordering per stream while preserving parallelism across different streams.