### PR TITLE
fix: add poke helper for updated timer

### DIFF
--- a/docs/findings/timerset-loop-stale-channel-on-arm.md
+++ b/docs/findings/timerset-loop-stale-channel-on-arm.md
@@ -1,0 +1,91 @@
+---
+date: May 14, 2026
+status: investigated
+component: Plan Worker Timer
+---
+
+# Findings: TimerSet.loop select captures stale nil channels on dynamic Arm
+
+## Problem Description
+
+When a `Schedule` timer (e.g., Requeue) is `Arm`ed **after** the `TimerSet.loop()` goroutine has already entered its `select` statement, the newly armed timer is never detected. The `select` evaluated `ts.Requeue.C()` as `nil` on entry (timer wasn't armed yet), and Go treats `<-nil` as "block forever" — permanently disabling that case for the current iteration.
+
+**Impact**: Any timer armed on-the-fly (e.g., Requeue set via `Apply()` or `SetRequeue()` during reconciliation) is silently ignored. The callback never fires, causing the worker to miss requeue cycles, timeouts, or deadlines until the loop happens to re-iterate due to another timer (typically the 30-minute inactivity timer).
+
+**Reproduction scenario**:
+1. `TimerSet.Start()` → loop goroutine enters `select` with only Inactivity armed
+2. External code calls `ts.SetRequeue(5s)` → `Requeue.Arm(5s)` creates a new timer
+3. 5 seconds pass → Requeue timer fires into its channel
+4. But loop's `select` captured `Requeue.C()` as `nil` → event is missed
+5. Loop remains blocked until Inactivity fires (30 min later)
+
+## Root Cause Analysis
+
+Go's `select` statement evaluates all channel operands **exactly once** when entering the select. If a channel expression returns `nil`, that case is permanently blocked for the duration of that select evaluation. The `select` does NOT re-evaluate channel expressions while it's waiting.
+
+```go
+// timer.go:192-234 — The problematic loop
+func (ts *TimerSet) loop(ctx context.Context) {
+    defer ts.wg.Done()
+    for {
+        select {
+        case <-ctx.Done():
+            return
+        // ⚠️ These channel expressions are evaluated ONCE per iteration.
+        // If Requeue.C() returns nil here, this case is dead until the
+        // loop re-iterates (which requires another case to fire first).
+        case <-ts.Requeue.C():   // nil if not armed → blocked forever
+            ts.send(...)
+        case <-ts.Timeout.C():   // nil if not armed → blocked forever
+            ts.send(...)
+        case <-ts.Deadline.C():  // nil if not armed → blocked forever
+            ts.send(...)
+        case <-ts.Inactivity.C():
+            ts.send(...)
+        }
+    }
+}
+```
+
+When `Schedule.Arm()` is called from another goroutine, it creates a **new** timer with a **new** channel. But the loop's `select` is still waiting on the old `nil` channel reference — it has no way to know a new channel was created.
+
+Additionally, `Schedule.Arm()` calls `disarmLocked()` first (stops + drains old timer), then creates a new timer. Even if the old timer's channel was captured by `select`, it would be stopped and never fire. The new timer's channel is invisible to the current `select` iteration.
+
+## Proposed Solutions
+
+### Option A: Notify channel (poke pattern)
+
+Add a buffered `notify chan struct{}` to `TimerSet`. Whenever a timer is armed or disarmed via `TimerSet` methods, send a non-blocking signal to this channel. The loop includes `<-ts.notify` as a case, which causes re-iteration and re-evaluation of all channel expressions.
+
+```go
+// TimerSet struct addition
+notify chan struct{}
+
+// New method
+func (ts *TimerSet) poke() {
+    select {
+    case ts.notify <- struct{}{}:
+    default: // already notified
+    }
+}
+
+// loop addition
+case <-ts.notify:
+    // Timer was armed/disarmed. Re-evaluate channels.
+```
+
+- **Pros**: Minimal change, zero-allocation (buffered chan), well-understood Go pattern, no polling
+- **Cons**: Extra goroutine wakeup per arm/disarm (negligible cost)
+
+### Option B: Reflect-based dynamic select
+
+Use `reflect.Select` to build the select cases dynamically each iteration, including only armed timers.
+
+- **Pros**: Eliminates nil channel cases entirely
+- **Cons**: Reflection overhead, harder to read, non-idiomatic for this use case
+
+## Impact
+
+- Timer events (requeue, timeout, deadline) armed after loop start are reliably detected
+- Eliminates silent 30-minute delays caused by missed requeue cycles
+- Fixes race condition in existing tests that only pass due to goroutine scheduling luck

--- a/internal/provider/processor/plan/timer.go
+++ b/internal/provider/processor/plan/timer.go
@@ -144,6 +144,7 @@ type TimerSet struct {
 	out    chan func(ctx context.Context, planCtx *message.PlanContext) bool
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
+	notify chan struct{}
 }
 
 // NewTimerSet creates a new TimerSet with the given clock, inactivity timeout, and hooks.
@@ -154,6 +155,7 @@ func NewTimerSet(log logr.Logger, clock clock.Clock, inactivityTimeout time.Dura
 		hooks:             hooks,
 		log:               log,
 		out:               make(chan func(ctx context.Context, planCtx *message.PlanContext) bool, 1),
+		notify:            make(chan struct{}, 1),
 	}
 	ts.Requeue = NewSchedule(clock, "requeue")
 	ts.Timeout = NewSchedule(clock, "timeout")
@@ -189,12 +191,21 @@ func (ts *TimerSet) C() <-chan func(ctx context.Context, planCtx *message.PlanCo
 }
 
 // loop multiplexes timer channels into ts.out.
+//
+// IMPORTANT: Go's select evaluates channel expressions once per iteration.
+// If a timer is not armed when select is entered, its C() returns nil and that
+// case is permanently blocked for that iteration. The notify channel (written
+// to by poke()) forces the loop to re-iterate whenever a timer is armed or
+// disarmed, ensuring the select picks up newly created timer channels.
 func (ts *TimerSet) loop(ctx context.Context) {
 	defer ts.wg.Done()
 	for {
 		select {
 		case <-ctx.Done():
 			return
+		case <-ts.notify:
+			// A timer was armed or disarmed; re-evaluate all channels.
+			ts.log.V(1).Info("poke received, re-evaluating timer channels")
 		case <-ts.Requeue.C():
 			ts.send(ts.Requeue.Name, func(ctx context.Context, planCtx *message.PlanContext) bool {
 				ts.Requeue.Disarm()
@@ -250,36 +261,52 @@ func (ts *TimerSet) send(name string, fn func(ctx context.Context, planCtx *mess
 // Lifecycle helpers
 // ---------------------------------------------------------------------------
 
+// poke signals the loop goroutine to re-evaluate timer channels.
+// It uses a non-blocking send on a buffered(1) channel, so multiple
+// rapid pokes coalesce into a single wakeup.
+func (ts *TimerSet) poke() {
+	select {
+	case ts.notify <- struct{}{}:
+	default:
+	}
+}
+
 // SetRequeue arms the requeue timer with the given duration.
 func (ts *TimerSet) SetRequeue(d time.Duration) {
 	ts.Requeue.Arm(d)
+	ts.poke()
 }
 
 // StopRequeue disarms the requeue timer.
 func (ts *TimerSet) StopRequeue() {
 	ts.Requeue.Disarm()
+	ts.poke()
 }
 
 // SetTimeout arms the timeout timer only if it is not already armed (arm-once).
 func (ts *TimerSet) SetTimeout(d time.Duration) {
 	if !ts.Timeout.IsArmed() {
 		ts.Timeout.Arm(d)
+		ts.poke()
 	}
 }
 
 // StopTimeout disarms the timeout timer.
 func (ts *TimerSet) StopTimeout() {
 	ts.Timeout.Disarm()
+	ts.poke()
 }
 
 // SetDeadline arms the deadline timer, always replacing any existing deadline.
 func (ts *TimerSet) SetDeadline(d time.Duration) {
 	ts.Deadline.Arm(d)
+	ts.poke()
 }
 
 // StopDeadline disarms the deadline timer.
 func (ts *TimerSet) StopDeadline() {
 	ts.Deadline.Disarm()
+	ts.poke()
 }
 
 // KeepAlive resets the inactivity timer. If a deadline is active and its duration

--- a/internal/provider/processor/plan/timer_test.go
+++ b/internal/provider/processor/plan/timer_test.go
@@ -499,6 +499,113 @@ func TestTimerSet_Loop_Stop_CancelsLoop(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// TimerSet — timer armed after loop starts (regression for stale nil channel)
+// ---------------------------------------------------------------------------
+
+func TestTimerSet_Loop_Requeue_ArmedAfterLoopStarts(t *testing.T) {
+	clk := clocktesting.NewFakeClock(time.Now())
+	requeueCalled := false
+	ts := NewTimerSet(logr.Discard(), clk, defaultWorkerIdleTimeout, TimerHooks{
+		OnRequeue: func(_ context.Context, _ *message.PlanContext) {
+			requeueCalled = true
+		},
+		OnTimeout:    func(_ context.Context, _ *message.PlanContext) {},
+		OnDeadline:   func(_ context.Context, _ *message.PlanContext) {},
+		OnInactivity: func() {},
+	})
+
+	ts.Start()
+	defer ts.Stop()
+
+	// Wait until the loop goroutine is blocked inside its select statement.
+	// At this point, select has captured Requeue.C() as nil (not armed yet).
+	assert.Eventually(t, clk.HasWaiters, time.Second, time.Millisecond,
+		"loop goroutine should be waiting on timers")
+
+	// Arm requeue AFTER the loop has entered select. Without the poke fix,
+	// the loop's select still holds the old nil channel and never fires.
+	ts.SetRequeue(time.Millisecond)
+
+	// Let the poke wake the loop and the loop re-enter select with the new channel.
+	assert.Eventually(t, clk.HasWaiters, time.Second, time.Millisecond,
+		"loop should re-enter select and wait on the new requeue timer")
+
+	// Fire the requeue timer.
+	clk.Step(time.Millisecond)
+
+	select {
+	case fn := <-ts.C():
+		ok := fn(context.Background(), nil)
+		assert.True(t, ok)
+		assert.True(t, requeueCalled)
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected requeue callback; loop did not pick up newly armed timer")
+	}
+}
+
+func TestTimerSet_Loop_Timeout_ArmedAfterLoopStarts(t *testing.T) {
+	clk := clocktesting.NewFakeClock(time.Now())
+	timeoutCalled := false
+	ts := NewTimerSet(logr.Discard(), clk, defaultWorkerIdleTimeout, TimerHooks{
+		OnRequeue:    func(_ context.Context, _ *message.PlanContext) {},
+		OnTimeout:    func(_ context.Context, _ *message.PlanContext) { timeoutCalled = true },
+		OnDeadline:   func(_ context.Context, _ *message.PlanContext) {},
+		OnInactivity: func() {},
+	})
+
+	ts.Start()
+	defer ts.Stop()
+
+	assert.Eventually(t, clk.HasWaiters, time.Second, time.Millisecond)
+
+	ts.SetTimeout(time.Millisecond)
+
+	assert.Eventually(t, clk.HasWaiters, time.Second, time.Millisecond)
+
+	clk.Step(time.Millisecond)
+
+	select {
+	case fn := <-ts.C():
+		ok := fn(context.Background(), nil)
+		assert.True(t, ok)
+		assert.True(t, timeoutCalled)
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected timeout callback; loop did not pick up newly armed timer")
+	}
+}
+
+func TestTimerSet_Loop_Deadline_ArmedAfterLoopStarts(t *testing.T) {
+	clk := clocktesting.NewFakeClock(time.Now())
+	deadlineCalled := false
+	ts := NewTimerSet(logr.Discard(), clk, defaultWorkerIdleTimeout, TimerHooks{
+		OnRequeue:    func(_ context.Context, _ *message.PlanContext) {},
+		OnTimeout:    func(_ context.Context, _ *message.PlanContext) {},
+		OnDeadline:   func(_ context.Context, _ *message.PlanContext) { deadlineCalled = true },
+		OnInactivity: func() {},
+	})
+
+	ts.Start()
+	defer ts.Stop()
+
+	assert.Eventually(t, clk.HasWaiters, time.Second, time.Millisecond)
+
+	ts.SetDeadline(time.Millisecond)
+
+	assert.Eventually(t, clk.HasWaiters, time.Second, time.Millisecond)
+
+	clk.Step(time.Millisecond)
+
+	select {
+	case fn := <-ts.C():
+		ok := fn(context.Background(), nil)
+		assert.True(t, ok)
+		assert.True(t, deadlineCalled)
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected deadline callback; loop did not pick up newly armed timer")
+	}
+}
+
+// ---------------------------------------------------------------------------
 // TimerSet — send buffer overflow
 // ---------------------------------------------------------------------------
 

--- a/internal/provider/processor/plan/worker.go
+++ b/internal/provider/processor/plan/worker.go
@@ -93,14 +93,15 @@ type Worker struct {
 // On each event the worker builds a fresh planState for the current phase and calls
 // Handle(ctx).
 func (s *Worker) run(ctx context.Context) {
-	s.timers = NewTimerSet(s.log.WithName("timerset"), s.Clock, defaultWorkerIdleTimeout, TimerHooks{
+	log := s.log.WithName("timerset").WithValues("plan", s.key)
+	s.timers = NewTimerSet(log, s.Clock, defaultWorkerIdleTimeout, TimerHooks{
 		OnDeadline: func(ctx context.Context, planCtx *message.PlanContext) {
 			if planCtx != nil {
 				s.handle(ctx, planCtx, true)
 			}
 		},
 		OnInactivity: func() {
-			s.log.V(1).Info("worker inactivity timeout reached, self-terminating", "plan", s.key)
+			log.Info("worker inactivity timeout reached, self-terminating")
 		},
 		OnRequeue: func(ctx context.Context, planCtx *message.PlanContext) {
 			if planCtx != nil {


### PR DESCRIPTION
# Summary

Fixes a bug where timers armed after the `TimerSet.loop()` goroutine enters its `select` statement are silently ignored, causing missed requeue cycles, timeouts, and deadlines.

## Background

PR #150 introduced the `TimerSet` and `Schedule` abstraction to centralize timer lifecycle management for the plan worker. This refactor moved the `select` loop from the worker's own goroutine into a dedicated background goroutine (`go ts.loop(ctx)`), while the worker goroutine arms/disarms timers via `TimerSet` methods like `SetRequeue()` and `SetDeadline()`.
The pre-revamp design was immune to this class of bug because `handle()` set timers synchronously within the same goroutine that owned the `select` loop. After `handle()` returned, the `for` loop re-entered `select` and `timerChan()` re-evaluated the (now non-nil) timer — all within a single goroutine, no stale references.

## The BUG

Go's `select` evaluates all channel expressions once when entering the statement. A `nil` channel (`<-nil`) blocks forever, effectively disabling that case for the entire iteration. The `select` does not re-evaluate channels while waiting.

With the `TimerSet` refactor, the `select` loop runs in a separate goroutine from the timer mutations:
```
Worker goroutine                    Loop goroutine
─────────────────                   ───────────────
                                    select {
                                      <- Requeue.C()  → evaluates to nil (not armed)
                                      <- Inactivity.C() → real channel
                                    }
                                    // blocked on Inactivity (30 min)...

ts.SetRequeue(5s)
  → Requeue.Arm(5s)
  → creates new timer
                                    // select still holds nil for Requeue
                                    // new timer fires into its own channel
                                    // but select never sees it ❌
```

The requeue callback never fires. The loop remains stuck until the 30-minute inactivity timer expires.

## The **Fix**

A buffered(1) `notify` channel is added to `TimerSet`. Whenever a timer is armed or disarmed via `Set*`/`Stop*` methods, a non-blocking send (poke) wakes the loop goroutine, forcing the `select` to re-iterate and re-evaluate all channel expressions — picking up the newly created timer channel.
https://github.com/ardikabs/hibernator/blob/3fef8ad6a4b3603535fe57000a9c4d89a3d3d9ce/internal/provider/processor/plan/timer.go#L267-L272
https://github.com/ardikabs/hibernator/blob/3fef8ad6a4b3603535fe57000a9c4d89a3d3d9ce/internal/provider/processor/plan/timer.go#L275-L278
