### PR TITLE
fix: prevent concurrent map read/write when marking jobs stale

### DIFF
--- a/cmd/kubectl-hibernator/cli/override/command.go
+++ b/cmd/kubectl-hibernator/cli/override/command.go
@@ -195,7 +195,7 @@ func runOverride(ctx context.Context, opts *overrideOptions, planName string) er
 	if !deadline.IsZero() {
 		out.Hint("Override Until: %s (%s)",
 			timeparse.FormatDeadline(deadline),
-			timeparse.FormatDuration(deadline))
+			timeparse.FormatDuration(time.Now(), deadline))
 	} else {
 		out.Warning("Override Indefinitely: the plan will stay locked at the target phase until you run: kubectl hibernator override %s --disable", planName)
 	}

--- a/cmd/kubectl-hibernator/cli/suspend/command.go
+++ b/cmd/kubectl-hibernator/cli/suspend/command.go
@@ -164,7 +164,7 @@ func runSuspend(ctx context.Context, opts *suspendOptions, planName string) erro
 	if !deadline.IsZero() {
 		out.Hint("Suspended Until: %s (%s)",
 			timeparse.FormatDeadline(deadline),
-			timeparse.FormatDuration(deadline))
+			timeparse.FormatDuration(time.Now(), deadline))
 	} else {
 		out.Warning("Suspended Indefinitely: the plan will stay suspended until you run: kubectl hibernator resume %s", planName)
 	}

--- a/cmd/runner/timeparse/timeparse.go
+++ b/cmd/runner/timeparse/timeparse.go
@@ -59,15 +59,15 @@ func ParseDeadline(input string, now time.Time) (time.Time, error) {
 
 	// Try each tier in order
 	if t, ok := parseNaturalLanguage(input, now); ok {
-		return validateDeadline(t)
+		return validateDeadline(t, now)
 	}
 
-	if t, ok := parseSimpleFormats(input); ok {
-		return validateDeadline(t)
+	if t, ok := parseSimpleFormats(input, now); ok {
+		return validateDeadline(t, now)
 	}
 
 	if t, ok := parseRFC3339(input); ok {
-		return validateDeadline(t)
+		return validateDeadline(t, now)
 	}
 
 	return time.Time{}, fmt.Errorf(
@@ -270,7 +270,8 @@ func parseTimeOfDay(input string) (time.Time, bool) {
 
 // parseSimpleFormats handles simple date/time formats without timezone info.
 // These are interpreted in the user's local timezone.
-func parseSimpleFormats(input string) (time.Time, bool) {
+// The now parameter provides the reference date for time-only inputs.
+func parseSimpleFormats(input string, now time.Time) (time.Time, bool) {
 	input = strings.TrimSpace(input)
 
 	// Try various date/time layouts
@@ -305,9 +306,8 @@ func parseSimpleFormats(input string) (time.Time, bool) {
 		}
 	}
 
-	// Try time-only formats (assumes today)
+	// Try time-only formats (assumes reference date from now)
 	if t, ok := parseTimeOfDay(input); ok {
-		now := time.Now()
 		result := time.Date(
 			now.Year(), now.Month(), now.Day(),
 			t.Hour(), t.Minute(), t.Second(), 0,
@@ -333,8 +333,8 @@ func parseRFC3339(input string) (time.Time, bool) {
 	return time.Time{}, false
 }
 
-// validateDeadline ensures the deadline is in the future.
-func validateDeadline(t time.Time) (time.Time, error) {
+// validateDeadline ensures the deadline is in the future relative to now.
+func validateDeadline(t, now time.Time) (time.Time, error) {
 	if t.IsZero() {
 		return time.Time{}, fmt.Errorf("parsed time is zero")
 	}
@@ -343,7 +343,7 @@ func validateDeadline(t time.Time) (time.Time, error) {
 	t = t.UTC()
 
 	// Check if deadline is in the past
-	if t.Before(time.Now().UTC()) {
+	if t.Before(now.UTC()) {
 		return time.Time{}, fmt.Errorf("deadline %s is in the past", t.Format(time.RFC3339))
 	}
 
@@ -375,13 +375,13 @@ func FormatDeadline(t time.Time) string {
 	)
 }
 
-// FormatDuration formats the time until a deadline in a human-readable way.
-func FormatDuration(until time.Time) string {
+// FormatDuration formats the duration from 'from' until 'until' in a human-readable way.
+func FormatDuration(from, until time.Time) string {
 	if until.IsZero() {
 		return ""
 	}
 
-	d := time.Until(until)
+	d := until.Sub(from)
 	if d < 0 {
 		return "overdue"
 	}

--- a/cmd/runner/timeparse/timeparse_test.go
+++ b/cmd/runner/timeparse/timeparse_test.go
@@ -360,7 +360,7 @@ func TestFormatDuration(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			until := now.Add(tt.d)
-			got := FormatDuration(until)
+			got := FormatDuration(now, until)
 			if !strings.Contains(got, tt.wantContains) {
 				t.Errorf("FormatDuration() = %v, should contain %v", got, tt.wantContains)
 			}

--- a/internal/provider/processor/plan/state/state_execution.go
+++ b/internal/provider/processor/plan/state/state_execution.go
@@ -363,7 +363,7 @@ func (s *state) updateExecutionStatuses(ctx context.Context,
 
 				// Mark job as stale immediately upon reaching terminal state.
 				// This prevents the job from being re-associated on restart.
-				go s.markJobAsStale(ctx, log, &job)
+				go s.markJobAsStale(ctx, log, job.DeepCopy())
 			}
 
 			if execID, ok := job.Labels[wellknown.LabelExecutionID]; ok {

--- a/log-panic.txt
+++ b/log-panic.txt
@@ -1,0 +1,2829 @@
+fatal error: concurrent map read and map write
+
+goroutine 726825 [running]:
+internal/runtime/maps.fatal({0x2490ba9?, 0xc00403e680?})
+	/usr/local/go/src/runtime/panic.go:1046 +0x18
+github.com/ardikabs/hibernator/internal/provider/processor/plan/state.(*state).executeForStage.JobExistsForTarget.func1(...)
+	/workspace/internal/provider/processor/plan/state/utils.go:239
+github.com/samber/lo.SomeBy[...](...)
+	/go/pkg/mod/github.com/samber/lo@v1.53.0/intersect.go:80
+github.com/ardikabs/hibernator/internal/provider/processor/plan/state.JobExistsForTarget(...)
+	/workspace/internal/provider/processor/plan/state/utils.go:237
+github.com/ardikabs/hibernator/internal/provider/processor/plan/state.(*state).executeForStage(0xc000356f00, {0x2815270, 0xc004c92f50}, {{0x281a520?, 0xc004119440?}, 0x1aa24d4?}, 0xc002388a08, {0xc0015d2a88, 0x2, 0x2}, ...)
+	/workspace/internal/provider/processor/plan/state/state_execution.go:180 +0xb99
+github.com/ardikabs/hibernator/internal/provider/processor/plan/state.(*state).execute(0xc000356f00, {0x2815270, 0xc004c92f50}, {{0x281a520?, 0xc004119440?}, 0x7f0bb7485108?}, {0x245fc9c, 0x6}, 0x1, 0xc000f9ba08, ...)
+	/workspace/internal/provider/processor/plan/state/state_execution.go:110 +0xb0f
+github.com/ardikabs/hibernator/internal/provider/processor/plan/state.(*wakingUpState).Handle(0xc004291210, {0x2815270, 0xc004c92f50})
+	/workspace/internal/provider/processor/plan/state/state_wakingup.go:45 +0x5a5
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*Worker).handleWithDepth(0xc0034ae600, {0x2815270, 0xc004c92f50}, 0xc00223a7d0, 0x0, 0x0)
+	/workspace/internal/provider/processor/plan/worker.go:200 +0x425
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*Worker).handle(...)
+	/workspace/internal/provider/processor/plan/worker.go:164
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*Worker).run(0xc0034ae600, {0x2815270, 0xc004c92f50})
+	/workspace/internal/provider/processor/plan/worker.go:132 +0x85c
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f6c0, {0x2815270, 0xc004c92f50}, {{0xc0047640f0, 0x222c7d7b3a226573?}, {0xc004764138?, 0x6472612e726f7461?}}, 0xc001208630?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 182
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 1 [select, 8119 minutes]:
+sigs.k8s.io/controller-runtime/pkg/manager.(*controllerManager).Start(0xc000344a80, {0x2815270, 0xc000112ff0})
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/internal.go:466 +0xa7a
+github.com/ardikabs/hibernator/cmd/controller/app.Run({{0x245e50e, 0x5}, {0x245e513, 0x5}, 0x1, {0xc00005607a, 0x11}, {0xc00005a057, 0x20}, {0x24712c3, ...}, ...})
+	/workspace/cmd/controller/app/app.go:190 +0x6f1
+main.main()
+	/workspace/cmd/controller/main.go:17 +0x5f
+
+goroutine 68 [chan receive, 8119 minutes]:
+sigs.k8s.io/controller-runtime/pkg/manager/signals.SetupSignalHandler.func1()
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/signals/signal.go:38 +0x27
+created by sigs.k8s.io/controller-runtime/pkg/manager/signals.SetupSignalHandler in goroutine 1
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/signals/signal.go:37 +0xc5
+
+goroutine 63 [select, 1 minutes]:
+github.com/ardikabs/hibernator/pkg/cache.(*Cache[...]).sweepLoop(0x283e560)
+	/workspace/pkg/cache/cache.go:345 +0xb6
+created by github.com/ardikabs/hibernator/pkg/cache.New[...] in goroutine 1
+	/workspace/pkg/cache/cache.go:187 +0x268
+
+goroutine 83 [syscall, 8119 minutes]:
+os/signal.signal_recv()
+	/usr/local/go/src/runtime/sigqueue.go:152 +0x29
+os/signal.loop()
+	/usr/local/go/src/os/signal/signal_unix.go:23 +0x13
+created by os/signal.Notify.func1.1 in goroutine 1
+	/usr/local/go/src/os/signal/signal.go:152 +0x1f
+
+goroutine 69 [chan receive, 8119 minutes]:
+sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile(0xc00053d3b0)
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/runnable_group.go:186 +0x45
+created by sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).Start.func1 in goroutine 1
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/runnable_group.go:139 +0xbf
+
+goroutine 70 [IO wait, 6741 minutes]:
+internal/poll.runtime_pollWait(0x7f0b709c6800, 0x72)
+	/usr/local/go/src/runtime/netpoll.go:351 +0x85
+internal/poll.(*pollDesc).wait(0xc00021e180?, 0x900000036?, 0x0)
+	/usr/local/go/src/internal/poll/fd_poll_runtime.go:84 +0x27
+internal/poll.(*pollDesc).waitRead(...)
+	/usr/local/go/src/internal/poll/fd_poll_runtime.go:89
+internal/poll.(*FD).Accept(0xc00021e180)
+	/usr/local/go/src/internal/poll/fd_unix.go:613 +0x28c
+net.(*netFD).accept(0xc00021e180)
+	/usr/local/go/src/net/fd_unix.go:161 +0x29
+net.(*TCPListener).accept(0xc000454180)
+	/usr/local/go/src/net/tcpsock_posix.go:159 +0x1b
+net.(*TCPListener).Accept(0xc000454180)
+	/usr/local/go/src/net/tcpsock.go:380 +0x30
+net/http.(*Server).Serve(0xc000312400, {0x280e0e0, 0xc000454180})
+	/usr/local/go/src/net/http/server.go:3463 +0x30c
+sigs.k8s.io/controller-runtime/pkg/metrics/server.(*defaultServer).Start(0xc0000007e0, {0x2815270, 0xc00052bb30})
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/metrics/server/server.go:265 +0x86b
+sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.func1(0xc00009c240)
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/runnable_group.go:226 +0xbf
+created by sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile in goroutine 69
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/runnable_group.go:210 +0x191
+
+goroutine 87 [chan receive, 8119 minutes]:
+sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile(0xc00053d440)
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/runnable_group.go:186 +0x45
+created by sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).Start.func1 in goroutine 1
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/runnable_group.go:139 +0xbf
+
+goroutine 84 [IO wait]:
+internal/poll.runtime_pollWait(0x7f0b709c6c00, 0x72)
+	/usr/local/go/src/runtime/netpoll.go:351 +0x85
+internal/poll.(*pollDesc).wait(0xc00010c380?, 0x900000036?, 0x0)
+	/usr/local/go/src/internal/poll/fd_poll_runtime.go:84 +0x27
+internal/poll.(*pollDesc).waitRead(...)
+	/usr/local/go/src/internal/poll/fd_poll_runtime.go:89
+internal/poll.(*FD).Accept(0xc00010c380)
+	/usr/local/go/src/internal/poll/fd_unix.go:613 +0x28c
+net.(*netFD).accept(0xc00010c380)
+	/usr/local/go/src/net/fd_unix.go:161 +0x29
+net.(*TCPListener).accept(0xc000529440)
+	/usr/local/go/src/net/tcpsock_posix.go:159 +0x1b
+net.(*TCPListener).Accept(0xc000529440)
+	/usr/local/go/src/net/tcpsock.go:380 +0x30
+net/http.(*Server).Serve(0xc000312100, {0x280e0e0, 0xc000529440})
+	/usr/local/go/src/net/http/server.go:3463 +0x30c
+sigs.k8s.io/controller-runtime/pkg/manager.(*Server).serve(0x281a520?)
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/server.go:106 +0x25
+sigs.k8s.io/controller-runtime/pkg/manager.(*Server).Start(0xc000454080, {0x2815270, 0xc00052bb30})
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/server.go:84 +0x332
+sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.func1(0xc00009c340)
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/runnable_group.go:226 +0xbf
+created by sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile in goroutine 69
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/runnable_group.go:210 +0x191
+
+goroutine 88 [IO wait, 6741 minutes]:
+internal/poll.runtime_pollWait(0x7f0b709c6400, 0x72)
+	/usr/local/go/src/runtime/netpoll.go:351 +0x85
+internal/poll.(*pollDesc).wait(0xc000346b00?, 0x900000036?, 0x0)
+	/usr/local/go/src/internal/poll/fd_poll_runtime.go:84 +0x27
+internal/poll.(*pollDesc).waitRead(...)
+	/usr/local/go/src/internal/poll/fd_poll_runtime.go:89
+internal/poll.(*FD).Accept(0xc000346b00)
+	/usr/local/go/src/internal/poll/fd_unix.go:613 +0x28c
+net.(*netFD).accept(0xc000346b00)
+	/usr/local/go/src/net/fd_unix.go:161 +0x29
+net.(*TCPListener).accept(0xc000529400)
+	/usr/local/go/src/net/tcpsock_posix.go:159 +0x1b
+net.(*TCPListener).Accept(0xc000529400)
+	/usr/local/go/src/net/tcpsock.go:380 +0x30
+crypto/tls.(*listener).Accept(0xc000490fa8)
+	/usr/local/go/src/crypto/tls/tls.go:79 +0x24
+net/http.(*Server).Serve(0xc0000da900, {0x2800140, 0xc000490fa8})
+	/usr/local/go/src/net/http/server.go:3463 +0x30c
+sigs.k8s.io/controller-runtime/pkg/webhook.(*DefaultServer).Start(0xc00003d720, {0x2815270, 0xc00052bb80})
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/webhook/server.go:263 +0x871
+sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.func1(0xc0002005a0)
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/runnable_group.go:226 +0xbf
+created by sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile in goroutine 87
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/runnable_group.go:210 +0x191
+
+goroutine 86 [chan receive, 8119 minutes]:
+sigs.k8s.io/controller-runtime/pkg/manager.(*Server).Start.func1()
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/server.go:67 +0x6e
+created by sigs.k8s.io/controller-runtime/pkg/manager.(*Server).Start in goroutine 84
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/server.go:66 +0x2f7
+
+goroutine 93 [chan receive, 8119 minutes]:
+sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile(0xc00053d4d0)
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/runnable_group.go:186 +0x45
+created by sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).Start.func1 in goroutine 1
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/runnable_group.go:139 +0xbf
+
+goroutine 72 [chan receive, 8119 minutes]:
+sigs.k8s.io/controller-runtime/pkg/metrics/server.(*defaultServer).Start.func1()
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/metrics/server/server.go:253 +0x45
+created by sigs.k8s.io/controller-runtime/pkg/metrics/server.(*defaultServer).Start in goroutine 70
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/metrics/server/server.go:252 +0x84e
+
+goroutine 90 [IO wait, 8119 minutes]:
+internal/poll.runtime_pollWait(0x7f0b709c6600, 0x72)
+	/usr/local/go/src/runtime/netpoll.go:351 +0x85
+internal/poll.(*pollDesc).wait(0xc000051ec0?, 0xc00058de53?, 0x1)
+	/usr/local/go/src/internal/poll/fd_poll_runtime.go:84 +0x27
+internal/poll.(*pollDesc).waitRead(...)
+	/usr/local/go/src/internal/poll/fd_poll_runtime.go:89
+internal/poll.(*FD).Read(0xc000051ec0, {0xc00058de53, 0x10000, 0x10000})
+	/usr/local/go/src/internal/poll/fd_unix.go:165 +0x279
+os.(*File).read(...)
+	/usr/local/go/src/os/file_posix.go:29
+os.(*File).Read(0xc00007cc78, {0xc00058de53?, 0x6f70736572222c22?, 0x22646e694b65736e?})
+	/usr/local/go/src/os/file.go:144 +0x4f
+github.com/fsnotify/fsnotify.(*inotify).readEvents(0xc000218500)
+	/go/pkg/mod/github.com/fsnotify/fsnotify@v1.9.0/backend_inotify.go:357 +0xcf
+created by github.com/fsnotify/fsnotify.newBackend in goroutine 88
+	/go/pkg/mod/github.com/fsnotify/fsnotify@v1.9.0/backend_inotify.go:155 +0x1f6
+
+goroutine 91 [select]:
+sigs.k8s.io/controller-runtime/pkg/certwatcher.(*CertWatcher).Start(0xc00033ebd0, {0x2815270, 0xc00052bb80})
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/certwatcher/certwatcher.go:135 +0x3c5
+sigs.k8s.io/controller-runtime/pkg/webhook.(*DefaultServer).Start.func1()
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/webhook/server.go:214 +0x1f
+created by sigs.k8s.io/controller-runtime/pkg/webhook.(*DefaultServer).Start in goroutine 88
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/webhook/server.go:213 +0x31f
+
+goroutine 92 [chan receive, 8119 minutes]:
+sigs.k8s.io/controller-runtime/pkg/webhook.(*DefaultServer).Start.func2()
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/webhook/server.go:248 +0x45
+created by sigs.k8s.io/controller-runtime/pkg/webhook.(*DefaultServer).Start in goroutine 88
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/webhook/server.go:247 +0x7eb
+
+goroutine 94 [chan receive, 8119 minutes]:
+sigs.k8s.io/controller-runtime/pkg/cache/internal.(*Informers).Start(0xc000277900, {0x2815270, 0xc00052bbd0})
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/cache/internal/informers.go:223 +0x49
+sigs.k8s.io/controller-runtime/pkg/cluster.(*cluster).Start(0xc0000a8310?, {0x2815270?, 0xc00052bbd0?})
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/cluster/internal.go:104 +0x6a
+sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.func1(0xc00009c160)
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/runnable_group.go:226 +0xbf
+created by sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile in goroutine 93
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/runnable_group.go:210 +0x191
+
+goroutine 76 [chan receive, 8119 minutes]:
+sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile(0xc00053d5f0)
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/runnable_group.go:186 +0x45
+created by sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).Start.func1 in goroutine 1
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/runnable_group.go:139 +0xbf
+
+goroutine 96 [sync.Cond.Wait, 176 minutes]:
+sync.runtime_notifyListWait(0xc0001b1428, 0xf)
+	/usr/local/go/src/runtime/sema.go:606 +0x159
+sync.(*Cond).Wait(0xc0053ac220?)
+	/usr/local/go/src/sync/cond.go:71 +0x73
+k8s.io/client-go/tools/cache.(*RealFIFO).Pop(0xc0001b1400, 0xc00021dbc0)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/the_real_fifo.go:207 +0x8b
+k8s.io/client-go/tools/cache.(*controller).processLoop(0xc0005c82c0, {0x2815510, 0xc0000a92d0})
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/controller.go:211 +0x5f
+k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext.func1({0x2815510?, 0xc0000a92d0?}, 0xc0005647b0?)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:255 +0x51
+k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext({0x2815510, 0xc0000a92d0}, 0xc000039d70, {0x27f0f20, 0xc0005647b0}, 0x1)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:256 +0xe5
+k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext({0x2815510, 0xc0000a92d0}, 0xc0006dcd70, 0x3b9aca00, 0x0, 0x1)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:223 +0x8f
+k8s.io/apimachinery/pkg/util/wait.UntilWithContext(...)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:172
+k8s.io/client-go/tools/cache.(*controller).RunWithContext(0xc0005c82c0, {0x2815510, 0xc0000a92d0})
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/controller.go:183 +0x418
+k8s.io/client-go/tools/cache.(*sharedIndexInformer).RunWithContext(0xc0005c8000, {0x2815510, 0xc0000a92d0})
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/shared_informer.go:587 +0x39a
+k8s.io/client-go/tools/cache.(*sharedIndexInformer).Run(0x2817ae0?, 0xc00007bf70?)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/shared_informer.go:526 +0x1d
+sigs.k8s.io/controller-runtime/pkg/cache/internal.(*Cache).Start(0xc00033e230, 0x0?)
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/cache/internal/informers.go:108 +0x72
+sigs.k8s.io/controller-runtime/pkg/cache/internal.(*Informers).startInformerLocked.func1()
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/cache/internal/informers.go:242 +0x75
+created by sigs.k8s.io/controller-runtime/pkg/cache/internal.(*Informers).startInformerLocked in goroutine 94
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/cache/internal/informers.go:240 +0x87
+
+goroutine 97 [select, 8119 minutes]:
+reflect.rselect({0xc000029f00, 0x3, 0x2?})
+	/usr/local/go/src/runtime/select.go:616 +0x3ce
+reflect.Select({0xc0005c8210?, 0x3, 0xc000344000?})
+	/usr/local/go/src/reflect/value.go:2949 +0x5ca
+sigs.k8s.io/controller-runtime/pkg/internal/syncs.MergeChans[...].func2()
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/internal/syncs/syncs.go:34 +0x4f
+created by sigs.k8s.io/controller-runtime/pkg/internal/syncs.MergeChans[...] in goroutine 96
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/internal/syncs/syncs.go:32 +0x3cc
+
+goroutine 77 [IO wait, 2 minutes]:
+internal/poll.runtime_pollWait(0x7f0b709c6200, 0x72)
+	/usr/local/go/src/runtime/netpoll.go:351 +0x85
+internal/poll.(*pollDesc).wait(0xc000347080?, 0x900000036?, 0x0)
+	/usr/local/go/src/internal/poll/fd_poll_runtime.go:84 +0x27
+internal/poll.(*pollDesc).waitRead(...)
+	/usr/local/go/src/internal/poll/fd_poll_runtime.go:89
+internal/poll.(*FD).Accept(0xc000347080)
+	/usr/local/go/src/internal/poll/fd_unix.go:613 +0x28c
+net.(*netFD).accept(0xc000347080)
+	/usr/local/go/src/net/fd_unix.go:161 +0x29
+net.(*TCPListener).accept(0xc000374580)
+	/usr/local/go/src/net/tcpsock_posix.go:159 +0x1b
+net.(*TCPListener).Accept(0xc000374580)
+	/usr/local/go/src/net/tcpsock.go:380 +0x30
+google.golang.org/grpc.(*Server).Serve(0xc000338200, {0x280e0e0, 0xc000374580})
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/server.go:890 +0x469
+github.com/ardikabs/hibernator/internal/streaming/server.(*GRPCServer).Start(0xc000529200, {0x2815270, 0xc00052bc70})
+	/workspace/internal/streaming/server/grpc.go:81 +0x285
+sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.func1(0xc0002019c0)
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/runnable_group.go:226 +0xbf
+created by sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile in goroutine 76
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/runnable_group.go:210 +0x191
+
+goroutine 99 [chan receive, 8119 minutes]:
+k8s.io/client-go/tools/cache.(*sharedProcessor).run(0xc000112140, {0x2815270, 0xc000113090})
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/shared_informer.go:893 +0x65
+k8s.io/client-go/tools/cache.(*sharedIndexInformer).RunWithContext.(*Group).StartWithContext.func4()
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:63 +0x1f
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:72 +0x4c
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 96
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:70 +0x73
+
+goroutine 100 [chan receive, 8119 minutes]:
+k8s.io/client-go/tools/cache.(*controller).RunWithContext.func1()
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/controller.go:151 +0x2c
+created by k8s.io/client-go/tools/cache.(*controller).RunWithContext in goroutine 96
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/controller.go:150 +0xdf
+
+goroutine 101 [select]:
+k8s.io/client-go/tools/cache.handleAnyWatch({0x2815510, 0xc0000a92d0}, {0xc003d355a8?, 0x0?, 0x3bb1060?}, {0x27fc198, 0xc0030bb5e0}, {0x7f0b706712f8, 0xc0001b1400}, {0x283e2d0, ...}, ...)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:892 +0x2b3
+k8s.io/client-go/tools/cache.handleWatch({0x2815510?, 0xc0000a92d0?}, {0xc003d355a8?, 0x0?, 0x3bb1060?}, {0x27fc198?, 0xc0030bb5e0?}, {0x7f0b706712f8?, 0xc0001b1400?}, {0x283e2d0, ...}, ...)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:850 +0xea
+k8s.io/client-go/tools/cache.(*Reflector).watch(0xc0001344b0, {0x2815510, 0xc0000a92d0}, {0x27fc198, 0xc0030bb5e0}, 0xc003604310)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:542 +0x60e
+k8s.io/client-go/tools/cache.(*Reflector).watchWithResync(0xc0001344b0, {0x2815510, 0xc0000a92d0}, {0x0, 0x0})
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:482 +0x186
+k8s.io/client-go/tools/cache.(*Reflector).ListAndWatchWithContext(0xc0001344b0, {0x2815510, 0xc0000a92d0})
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:437 +0x3f2
+k8s.io/client-go/tools/cache.(*Reflector).RunWithContext.func1()
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:360 +0x2e
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1({0x1217b16?, 0xc003407340?})
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:233 +0x13
+k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext.func1({0x2815510?, 0xc0000a92d0?}, 0x41c800?)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:255 +0x51
+k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext({0x2815510, 0xc0000a92d0}, 0xc000037ea8, {0x27f0f40, 0xc0001130e0}, 0x1)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:256 +0xe5
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x281a1e0?, {0x27f0f40?, 0xc0001130e0?}, 0x72?, 0x12?)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:233 +0x46
+k8s.io/client-go/tools/cache.(*Reflector).RunWithContext(0xc0001344b0, {0x2815510, 0xc0000a92d0})
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:359 +0x22b
+k8s.io/client-go/tools/cache.(*controller).RunWithContext.(*Group).StartWithContext.func3()
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:63 +0x1f
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:72 +0x4c
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 96
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:70 +0x73
+
+goroutine 73 [select, 8119 minutes]:
+sigs.k8s.io/controller-runtime/pkg/certwatcher.(*CertWatcher).Watch(0xc00033ebd0)
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/certwatcher/certwatcher.go:149 +0xc5
+created by sigs.k8s.io/controller-runtime/pkg/certwatcher.(*CertWatcher).Start in goroutine 91
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/certwatcher/certwatcher.go:128 +0x27e
+
+goroutine 726512 [select, 9 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2.1()
+	/workspace/internal/provider/processor/requeue/processor.go:116 +0x111
+created by github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2 in goroutine 183
+	/workspace/internal/provider/processor/requeue/processor.go:112 +0x78d
+
+goroutine 107 [select, 19 minutes]:
+github.com/ardikabs/hibernator/internal/streaming/server.(*ExecutionServiceServer).StartCleanupRoutine(0xc00053cbd0, {0x2815270, 0xc00052bc70}, 0x34630b8a000)
+	/workspace/internal/streaming/server/service.go:412 +0xed
+created by github.com/ardikabs/hibernator/internal/streaming/server.(*GRPCServer).Start in goroutine 77
+	/workspace/internal/streaming/server/grpc.go:72 +0x205
+
+goroutine 732490 [sync.Cond.Wait]:
+sync.runtime_notifyListWait(0xc004ac8348, 0x80)
+	/usr/local/go/src/runtime/sema.go:606 +0x159
+sync.(*Cond).Wait(0x3?)
+	/usr/local/go/src/sync/cond.go:71 +0x73
+golang.org/x/net/http2.(*pipe).Read(0xc004ac8330, {0xc004ebb038, 0x4, 0x4})
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/pipe.go:76 +0xdb
+golang.org/x/net/http2.transportResponseBody.Read({0x0?}, {0xc004ebb038?, 0xc003ef7cd0?, 0x41d305?})
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/transport.go:2560 +0x59
+io.ReadAtLeast({0x7f0b707dc000, 0xc004ac8300}, {0xc004ebb038, 0x4, 0x4}, 0x4)
+	/usr/local/go/src/io/io.go:335 +0x8e
+k8s.io/apimachinery/pkg/util/framer.(*lengthDelimitedFrameReader).Read(0xc0054379e0, {0xc000d8a000, 0x2000, 0x2500})
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/framer/framer.go:76 +0x7f
+k8s.io/apimachinery/pkg/runtime/serializer/streaming.(*decoder).Decode(0xc00425fc20, 0x0, {0x27fbf90, 0xc004840480})
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/runtime/serializer/streaming/streaming.go:77 +0xa3
+k8s.io/client-go/rest/watch.(*Decoder).Decode(0xc0047dfc80)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/rest/watch/decoder.go:49 +0x4b
+k8s.io/apimachinery/pkg/watch.(*StreamWatcher).receive(0xc00425fc70)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/watch/streamwatcher.go:114 +0xf8
+created by k8s.io/apimachinery/pkg/watch.NewStreamWatcherWithLogger in goroutine 252
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/watch/streamwatcher.go:85 +0x149
+
+goroutine 79 [chan receive, 8119 minutes]:
+github.com/ardikabs/hibernator/internal/streaming/server.(*WebSocketServer).Start(0xc000000700, {0x2815270, 0xc00052bc70})
+	/workspace/internal/streaming/server/websocket.go:136 +0x205
+sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.func1(0xc0002019e0)
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/runnable_group.go:226 +0xbf
+created by sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile in goroutine 76
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/runnable_group.go:210 +0x191
+
+goroutine 114 [select]:
+k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext({0x2815510, 0xc0000ae5b0}, 0xc003535e40, {0x27f0f20, 0xc0000ac690}, 0x1)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:267 +0x185
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x0?, {0x27f0f20?, 0xc0000ac690?}, 0xb0?, 0xc000033e70?)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:233 +0x46
+k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc000033ee0, 0x77359400, 0x0, 0x1, 0xc0000ae5b0)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:210 +0x7f
+k8s.io/apimachinery/pkg/util/wait.Until(...)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:163
+k8s.io/client-go/tools/leaderelection.(*LeaderElector).renew(0xc000424000, {0x2815270?, 0xc000113e50?})
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/leaderelection/leaderelection.go:282 +0xf4
+k8s.io/client-go/tools/leaderelection.(*LeaderElector).Run(0xc000424000, {0x2815270, 0xc000376be0})
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/leaderelection/leaderelection.go:221 +0xfa
+sigs.k8s.io/controller-runtime/pkg/manager.(*controllerManager).Start.func3()
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/internal.go:449 +0x32
+created by sigs.k8s.io/controller-runtime/pkg/manager.(*controllerManager).Start in goroutine 1
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/internal.go:448 +0x994
+
+goroutine 113 [IO wait, 6741 minutes]:
+internal/poll.runtime_pollWait(0x7f0b709c6000, 0x72)
+	/usr/local/go/src/runtime/netpoll.go:351 +0x85
+internal/poll.(*pollDesc).wait(0xc00021e400?, 0x900000036?, 0x0)
+	/usr/local/go/src/internal/poll/fd_poll_runtime.go:84 +0x27
+internal/poll.(*pollDesc).waitRead(...)
+	/usr/local/go/src/internal/poll/fd_poll_runtime.go:89
+internal/poll.(*FD).Accept(0xc00021e400)
+	/usr/local/go/src/internal/poll/fd_unix.go:613 +0x28c
+net.(*netFD).accept(0xc00021e400)
+	/usr/local/go/src/net/fd_unix.go:161 +0x29
+net.(*TCPListener).accept(0xc000454640)
+	/usr/local/go/src/net/tcpsock_posix.go:159 +0x1b
+net.(*TCPListener).Accept(0xc000454640)
+	/usr/local/go/src/net/tcpsock.go:380 +0x30
+net/http.(*Server).Serve(0xc000312f00, {0x280e0e0, 0xc000454640})
+	/usr/local/go/src/net/http/server.go:3463 +0x30c
+net/http.(*Server).ListenAndServe(0xc000312f00)
+	/usr/local/go/src/net/http/server.go:3389 +0x72
+github.com/ardikabs/hibernator/internal/streaming/server.(*WebSocketServer).Start.func1()
+	/workspace/internal/streaming/server/websocket.go:130 +0x25
+created by github.com/ardikabs/hibernator/internal/streaming/server.(*WebSocketServer).Start in goroutine 79
+	/workspace/internal/streaming/server/websocket.go:129 +0x1e8
+
+goroutine 108 [chan receive, 8119 minutes]:
+github.com/ardikabs/hibernator/internal/streaming/server.(*GRPCServer).Start.func1()
+	/workspace/internal/streaming/server/grpc.go:76 +0x2c
+created by github.com/ardikabs/hibernator/internal/streaming/server.(*GRPCServer).Start in goroutine 77
+	/workspace/internal/streaming/server/grpc.go:75 +0x26b
+
+goroutine 167 [chan receive, 8119 minutes]:
+sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile(0xc00053d560)
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/runnable_group.go:186 +0x45
+created by sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).Start.func1 in goroutine 164
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/runnable_group.go:139 +0xbf
+
+goroutine 168 [chan receive, 8118 minutes]:
+sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start(0x282c900, {0x2815270, 0xc00052bc20})
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/internal/controller/controller.go:252 +0x1a9
+sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.func1(0xc0005ced00)
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/runnable_group.go:226 +0xbf
+created by sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile in goroutine 167
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/runnable_group.go:210 +0x191
+
+goroutine 170 [chan receive]:
+k8s.io/client-go/util/workqueue.(*Typed[...]).updateUnfinishedWorkLoop(0x28279c0)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/util/workqueue/queue.go:336 +0x92
+created by k8s.io/client-go/util/workqueue.newQueue[...] in goroutine 168
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/util/workqueue/queue.go:177 +0x1e8
+
+goroutine 726431 [select]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).loop(0xc001c92000, {0x2815270, 0xc0043d40a0})
+	/workspace/internal/provider/processor/plan/timer.go:203 +0x177
+created by github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).Start in goroutine 726430
+	/workspace/internal/provider/processor/plan/timer.go:174 +0xd0
+
+goroutine 726545 [select]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*Worker).run(0xc00134ed00, {0x2815270, 0xc00375a5f0})
+	/workspace/internal/provider/processor/plan/worker.go:122 +0x6fe
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f6c0, {0x2815270, 0xc00375a5f0}, {{0xc000798c78, 0x92ad28?}, {0xc000798d20?, 0xc00130f748?}}, 0xc0012682d0?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 182
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 238 [select, 8119 minutes]:
+context.(*cancelCtx).propagateCancel.func2()
+	/usr/local/go/src/context/context.go:523 +0x98
+created by context.(*cancelCtx).propagateCancel in goroutine 252
+	/usr/local/go/src/context/context.go:522 +0x409
+
+goroutine 163 [select, 8119 minutes]:
+k8s.io/client-go/tools/record.(*eventBroadcasterImpl).StartEventWatcher.func1()
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/record/event.go:407 +0xfe
+created by k8s.io/client-go/tools/record.(*eventBroadcasterImpl).StartEventWatcher in goroutine 114
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/record/event.go:404 +0xb2
+
+goroutine 161 [chan receive, 8119 minutes]:
+k8s.io/apimachinery/pkg/watch.(*Broadcaster).loop(0xc000113d60)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/watch/mux.go:268 +0x66
+created by k8s.io/apimachinery/pkg/watch.NewLongQueueBroadcaster in goroutine 114
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/watch/mux.go:93 +0x116
+
+goroutine 162 [select, 8118 minutes]:
+k8s.io/client-go/tools/record.(*eventBroadcasterImpl).StartEventWatcher.func1()
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/record/event.go:407 +0xfe
+created by k8s.io/client-go/tools/record.(*eventBroadcasterImpl).StartEventWatcher in goroutine 114
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/record/event.go:404 +0xb2
+
+goroutine 733333 [select, 2 minutes]:
+google.golang.org/grpc/internal/transport.(*http2Server).keepalive(0xc001883520)
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/internal/transport/http2_server.go:1197 +0x1ea
+created by google.golang.org/grpc/internal/transport.NewServerTransport in goroutine 733331
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/internal/transport/http2_server.go:357 +0x18dd
+
+goroutine 727143 [select, 6 minutes]:
+github.com/ardikabs/hibernator/internal/notification.(*Dispatcher).workerFactory-fm.(*Dispatcher).workerFactory.func1({0x2815270, 0xc002b51360})
+	/workspace/internal/notification/dispatcher.go:345 +0x2ce
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f560, {0x2815270, 0xc002b51360}, {{{0xc0047bb110, 0x11}, {0xc0047bb0f8, 0x14}}, {0xc004f34070, 0x8}, {{0xc002450b40, ...}, ...}, ...}, ...)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c7
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 726438
+	/workspace/pkg/keyedworker/pool.go:312 +0x2c7
+
+goroutine 160 [sync.Cond.Wait]:
+sync.runtime_notifyListWait(0xc000355b08, 0x790ef)
+	/usr/local/go/src/runtime/sema.go:606 +0x159
+sync.(*Cond).Wait(0xc0049f0700?)
+	/usr/local/go/src/sync/cond.go:71 +0x73
+k8s.io/client-go/tools/cache.(*RealFIFO).Pop(0xc000355ae0, 0xc000497f30)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/the_real_fifo.go:207 +0x8b
+k8s.io/client-go/tools/cache.(*controller).processLoop(0xc000314210, {0x2815510, 0xc0007cbce0})
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/controller.go:211 +0x5f
+k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext.func1({0x2815510?, 0xc0007cbce0?}, 0xc0007ed290?)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:255 +0x51
+k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext({0x2815510, 0xc0007cbce0}, 0xc00067fd70, {0x27f0f20, 0xc0007ed290}, 0x1)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:256 +0xe5
+k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext({0x2815510, 0xc0007cbce0}, 0xc0007b7d70, 0x3b9aca00, 0x0, 0x1)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:223 +0x8f
+k8s.io/apimachinery/pkg/util/wait.UntilWithContext(...)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:172
+k8s.io/client-go/tools/cache.(*controller).RunWithContext(0xc000314210, {0x2815510, 0xc0007cbce0})
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/controller.go:183 +0x418
+k8s.io/client-go/tools/cache.(*sharedIndexInformer).RunWithContext(0xc0003140b0, {0x2815510, 0xc0007cbce0})
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/shared_informer.go:587 +0x39a
+k8s.io/client-go/tools/cache.(*sharedIndexInformer).Run(0x2817ae0?, 0xc0007b7f70?)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/shared_informer.go:526 +0x1d
+sigs.k8s.io/controller-runtime/pkg/cache/internal.(*Cache).Start(0xc00048a9a0, 0x0?)
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/cache/internal/informers.go:108 +0x72
+sigs.k8s.io/controller-runtime/pkg/cache/internal.(*Informers).startInformerLocked.func1()
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/cache/internal/informers.go:242 +0x75
+created by sigs.k8s.io/controller-runtime/pkg/cache/internal.(*Informers).startInformerLocked in goroutine 159
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/cache/internal/informers.go:240 +0x87
+
+goroutine 171 [select]:
+k8s.io/client-go/util/workqueue.(*delayingType[...]).waitingLoop(0x2825400, {{0x281a1e0, 0xc0000a66c0?}, 0xc000454d80?})
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/util/workqueue/delaying_queue.go:320 +0x385
+created by k8s.io/client-go/util/workqueue.newDelayingQueue[...] in goroutine 168
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/util/workqueue/delaying_queue.go:157 +0x272
+
+goroutine 172 [chan receive, 8119 minutes]:
+sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1()
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/internal/controller/controller.go:162 +0x2c
+created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start in goroutine 168
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/internal/controller/controller.go:161 +0x153
+
+goroutine 268 [sync.Cond.Wait]:
+sync.runtime_notifyListWait(0xc0005d33d0, 0x1d6)
+	/usr/local/go/src/runtime/sema.go:606 +0x159
+sync.(*Cond).Wait(0xc0030b2ac8?)
+	/usr/local/go/src/sync/cond.go:71 +0x73
+k8s.io/client-go/util/workqueue.(*Typed[...]).Get(0x28279c0)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/util/workqueue/queue.go:260 +0xbe
+sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem(0x282c900, {0x2815270, 0xc00052bc20})
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/internal/controller/controller.go:262 +0x5b
+sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2()
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/internal/controller/controller.go:240 +0x85
+created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2 in goroutine 168
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/internal/controller/controller.go:236 +0x551
+
+goroutine 733491 [select, 2 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2.1()
+	/workspace/internal/provider/processor/requeue/processor.go:116 +0x111
+created by github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2 in goroutine 183
+	/workspace/internal/provider/processor/requeue/processor.go:112 +0x78d
+
+goroutine 281 [select]:
+k8s.io/client-go/tools/cache.(*processorListener).pop(0xc00053a320)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/shared_informer.go:1031 +0x129
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:72 +0x4c
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 192
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:70 +0x73
+
+goroutine 182 [select]:
+github.com/ardikabs/hibernator/internal/message.HandleSubscription[...]({0x2815270, 0xc00052bc20}, {{0x281a520, 0xc0000ad2f0?}, 0x0?}, {{0x2468080, 0xb}, {0x246cd40, 0xe}}, 0xc0000aefc0?, ...)
+	/workspace/internal/message/watchutil.go:58 +0x379
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*Coordinator).Start(0xc0005c8160, {0x2815270, 0xc00052bc20})
+	/workspace/internal/provider/processor/plan/coordinator.go:70 +0x3bb
+sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.func1(0xc0002000a0)
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/runnable_group.go:226 +0xbf
+created by sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile in goroutine 167
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/runnable_group.go:210 +0x191
+
+goroutine 183 [select]:
+github.com/ardikabs/hibernator/internal/message.HandleSubscription[...]({0x2815270, 0xc00052bc20}, {{0x281a520, 0xc0000ad1a0?}, 0x7f0b707493c0?}, {{0x24699ee, 0xc}, {0x246cd40, 0xe}}, 0xc0000aec40?, ...)
+	/workspace/internal/message/watchutil.go:58 +0x379
+github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start(0xc00022b200, {0x2815270, 0xc00052bc20})
+	/workspace/internal/provider/processor/requeue/processor.go:67 +0x285
+sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.func1(0xc0002002a0)
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/runnable_group.go:226 +0xbf
+created by sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile in goroutine 167
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/runnable_group.go:210 +0x191
+
+goroutine 180 [select, 9 minutes]:
+sigs.k8s.io/controller-runtime/pkg/source.(*channel[...]).syncLoop(0x282c9c0, {0x2815270, 0xc00052bc20})
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/source/source.go:247 +0xb7
+created by sigs.k8s.io/controller-runtime/pkg/source.(*channel[...]).Start.func1 in goroutine 179
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/source/source.go:196 +0xa5
+
+goroutine 181 [chan receive, 9 minutes]:
+sigs.k8s.io/controller-runtime/pkg/source.(*channel[...]).Start.func2()
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/source/source.go:200 +0x7c
+created by sigs.k8s.io/controller-runtime/pkg/source.(*channel[...]).Start in goroutine 179
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/source/source.go:199 +0x2dc
+
+goroutine 250 [chan receive, 8119 minutes]:
+k8s.io/client-go/tools/cache.(*sharedProcessor).run(0xc000488c80, {0x2815270, 0xc000488d20})
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/shared_informer.go:893 +0x65
+k8s.io/client-go/tools/cache.(*sharedIndexInformer).RunWithContext.(*Group).StartWithContext.func4()
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:63 +0x1f
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:72 +0x4c
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 246
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:70 +0x73
+
+goroutine 185 [select]:
+github.com/telepresenceio/watchable.(*Map[...]).coalesce(0x28487c0, {0x2815270, 0xc00052bc20}, 0xc00021c600, 0xc0000aebd0, 0xc0000aec40, 0xc0000ad230)
+	/go/pkg/mod/github.com/telepresenceio/watchable@v0.0.0-20220726211108-9bb86f92afa7/map.go:382 +0x72c
+created by github.com/telepresenceio/watchable.(*Map[...]).SubscribeSubset in goroutine 183
+	/go/pkg/mod/github.com/telepresenceio/watchable@v0.0.0-20220726211108-9bb86f92afa7/map.go:281 +0x145
+
+goroutine 186 [chan receive, 8119 minutes]:
+github.com/ardikabs/hibernator/internal/message.HandleSubscription[...].func1()
+	/workspace/internal/message/watchutil.go:49 +0x15f
+created by github.com/ardikabs/hibernator/internal/message.HandleSubscription[...] in goroutine 183
+	/workspace/internal/message/watchutil.go:48 +0x2b0
+
+goroutine 189 [chan receive, 176 minutes]:
+k8s.io/client-go/tools/cache.(*processorListener).run(0xc000247d60)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/shared_informer.go:1062 +0x4e
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:72 +0x4c
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 188
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:70 +0x73
+
+goroutine 190 [select, 176 minutes]:
+k8s.io/client-go/tools/cache.(*processorListener).pop(0xc000247d60)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/shared_informer.go:1031 +0x129
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:72 +0x4c
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 188
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:70 +0x73
+
+goroutine 726505 [select, 9 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).loop(0xc002ec37c0, {0x2815270, 0xc0043aa460})
+	/workspace/internal/provider/processor/plan/timer.go:203 +0x177
+created by github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).Start in goroutine 726504
+	/workspace/internal/provider/processor/plan/timer.go:174 +0xd0
+
+goroutine 726839 [select, 8 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/status.(*UpdateProcessor[...].func3.1()
+	/workspace/pkg/keyedworker/handler.go:64 +0x191
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283efe0, {0x2815270, 0xc0031f05a0}, {{0xc003cf6870, 0x92ad28?}, {0xc003cf6948?, 0xc00167e310?}}, 0xc003f71bc0?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 726837
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 248 [select, 8119 minutes]:
+reflect.rselect({0xc000676f00, 0x3, 0x0?})
+	/usr/local/go/src/runtime/select.go:616 +0x3ce
+reflect.Select({0xc0005c8790?, 0x3, 0x0?})
+	/usr/local/go/src/reflect/value.go:2949 +0x5ca
+sigs.k8s.io/controller-runtime/pkg/internal/syncs.MergeChans[...].func2()
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/internal/syncs/syncs.go:34 +0x4f
+created by sigs.k8s.io/controller-runtime/pkg/internal/syncs.MergeChans[...] in goroutine 246
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/internal/syncs/syncs.go:32 +0x3cc
+
+goroutine 194 [select]:
+github.com/telepresenceio/watchable.(*Map[...]).coalesce(0x28487c0, {0x2815270, 0xc00052bc20}, 0xc00021c750, 0xc0000aef50, 0xc0000aefc0, 0xc0000ad380)
+	/go/pkg/mod/github.com/telepresenceio/watchable@v0.0.0-20220726211108-9bb86f92afa7/map.go:382 +0x72c
+created by github.com/telepresenceio/watchable.(*Map[...]).SubscribeSubset in goroutine 182
+	/go/pkg/mod/github.com/telepresenceio/watchable@v0.0.0-20220726211108-9bb86f92afa7/map.go:281 +0x145
+
+goroutine 195 [chan receive, 8119 minutes]:
+github.com/ardikabs/hibernator/internal/message.HandleSubscription[...].func1()
+	/workspace/internal/message/watchutil.go:49 +0x15f
+created by github.com/ardikabs/hibernator/internal/message.HandleSubscription[...] in goroutine 182
+	/workspace/internal/message/watchutil.go:48 +0x2b0
+
+goroutine 196 [select]:
+github.com/ardikabs/hibernator/internal/message.HandleSubscription[...]({0x2815270, 0xc00052bc20}, {{0x281a520, 0xc0000ad4d0?}, 0x7f0b70684de0?}, {{0x24765a7, 0x13}, {0x246cd40, 0xe}}, 0xc0000af0a0?, ...)
+	/workspace/internal/message/watchutil.go:58 +0x379
+github.com/ardikabs/hibernator/internal/provider/processor/scheduleexception.(*LifecycleProcessor).Start(0xc000112410, {0x2815270, 0xc00052bc20})
+	/workspace/internal/provider/processor/scheduleexception/lifecycle.go:62 +0x1af
+sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.func1(0xc000200300)
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/runnable_group.go:226 +0xbf
+created by sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile in goroutine 167
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/runnable_group.go:210 +0x191
+
+goroutine 197 [chan receive, 8119 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/status.(*UpdateProcessor[...]).Start(0x282afc0, {0x2815270, 0xc00052bc20})
+	/workspace/internal/provider/processor/status/processor.go:157 +0x245
+sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.func1(0xc000200340)
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/runnable_group.go:226 +0xbf
+created by sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile in goroutine 167
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/runnable_group.go:210 +0x191
+
+goroutine 251 [chan receive, 8119 minutes]:
+k8s.io/client-go/tools/cache.(*controller).RunWithContext.func1()
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/controller.go:151 +0x2c
+created by k8s.io/client-go/tools/cache.(*controller).RunWithContext in goroutine 246
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/controller.go:150 +0xdf
+
+goroutine 266 [chan receive]:
+k8s.io/client-go/tools/cache.(*processorListener).run(0xc0008739a0)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/shared_informer.go:1062 +0x4e
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:72 +0x4c
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 213
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:70 +0x73
+
+goroutine 727288 [select, 6 minutes]:
+github.com/ardikabs/hibernator/internal/notification.(*Dispatcher).workerFactory-fm.(*Dispatcher).workerFactory.func1({0x2815270, 0xc0040310e0})
+	/workspace/internal/notification/dispatcher.go:345 +0x2ce
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f560, {0x2815270, 0xc0040310e0}, {{{0xc002a64a80, 0x11}, {0xc0040a7340, 0x10}}, {0xc0040a73e0, 0x8}, {{0xc002450b40, ...}, ...}, ...}, ...)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c7
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 726851
+	/workspace/pkg/keyedworker/pool.go:312 +0x2c7
+
+goroutine 726463 [select, 9 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2.1()
+	/workspace/internal/provider/processor/requeue/processor.go:116 +0x111
+created by github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2 in goroutine 183
+	/workspace/internal/provider/processor/requeue/processor.go:112 +0x78d
+
+goroutine 726547 [select, 8 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/status.(*UpdateProcessor[...].func3.1()
+	/workspace/pkg/keyedworker/handler.go:64 +0x191
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283efe0, {0x2815270, 0xc00375a6e0}, {{0xc000798c78, 0x92ad28?}, {0xc000798d20?, 0xc00130f748?}}, 0xc003528840?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 726545
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 214 [select, 8119 minutes]:
+reflect.rselect({0xc0004b7f00, 0x3, 0x24776a1?})
+	/usr/local/go/src/runtime/select.go:616 +0x3ce
+reflect.Select({0xc000314160?, 0x3, 0x1a7ed20?})
+	/usr/local/go/src/reflect/value.go:2949 +0x5ca
+sigs.k8s.io/controller-runtime/pkg/internal/syncs.MergeChans[...].func2()
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/internal/syncs/syncs.go:34 +0x4f
+created by sigs.k8s.io/controller-runtime/pkg/internal/syncs.MergeChans[...] in goroutine 160
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/internal/syncs/syncs.go:32 +0x3cc
+
+goroutine 222 [sync.Cond.Wait]:
+sync.runtime_notifyListWait(0xc000355c48, 0x4a0)
+	/usr/local/go/src/runtime/sema.go:606 +0x159
+sync.(*Cond).Wait(0xc00435fb40?)
+	/usr/local/go/src/sync/cond.go:71 +0x73
+k8s.io/client-go/tools/cache.(*RealFIFO).Pop(0xc000355c20, 0xc000310b50)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/the_real_fifo.go:207 +0x8b
+k8s.io/client-go/tools/cache.(*controller).processLoop(0xc000314420, {0x2815510, 0xc00030a2a0})
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/controller.go:211 +0x5f
+k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext.func1({0x2815510?, 0xc00030a2a0?}, 0xc00031eae0?)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:255 +0x51
+k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext({0x2815510, 0xc00030a2a0}, 0xc0004b8d70, {0x27f0f20, 0xc00031eae0}, 0x1)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:256 +0xe5
+k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext({0x2815510, 0xc00030a2a0}, 0xc0004b8d70, 0x3b9aca00, 0x0, 0x1)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:223 +0x8f
+k8s.io/apimachinery/pkg/util/wait.UntilWithContext(...)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:172
+k8s.io/client-go/tools/cache.(*controller).RunWithContext(0xc000314420, {0x2815510, 0xc00030a2a0})
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/controller.go:183 +0x418
+k8s.io/client-go/tools/cache.(*sharedIndexInformer).RunWithContext(0xc0003142c0, {0x2815510, 0xc00030a2a0})
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/shared_informer.go:587 +0x39a
+k8s.io/client-go/tools/cache.(*sharedIndexInformer).Run(0x2817ae0?, 0xc0004b8f70?)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/shared_informer.go:526 +0x1d
+sigs.k8s.io/controller-runtime/pkg/cache/internal.(*Cache).Start(0xc00048bce0, 0xc0005d34c0?)
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/cache/internal/informers.go:108 +0x72
+sigs.k8s.io/controller-runtime/pkg/cache/internal.(*Informers).startInformerLocked.func1()
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/cache/internal/informers.go:242 +0x75
+created by sigs.k8s.io/controller-runtime/pkg/cache/internal.(*Informers).startInformerLocked in goroutine 211
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/cache/internal/informers.go:240 +0x87
+
+goroutine 216 [chan receive, 8119 minutes]:
+k8s.io/client-go/tools/cache.(*sharedProcessor).run(0xc000377950, {0x2815270, 0xc000377a90})
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/shared_informer.go:893 +0x65
+k8s.io/client-go/tools/cache.(*sharedIndexInformer).RunWithContext.(*Group).StartWithContext.func4()
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:63 +0x1f
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:72 +0x4c
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 160
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:70 +0x73
+
+goroutine 217 [chan receive, 8119 minutes]:
+k8s.io/client-go/tools/cache.(*controller).RunWithContext.func1()
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/controller.go:151 +0x2c
+created by k8s.io/client-go/tools/cache.(*controller).RunWithContext in goroutine 160
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/controller.go:150 +0xdf
+
+goroutine 218 [select]:
+k8s.io/client-go/tools/cache.handleAnyWatch({0x2815510, 0xc0007cbce0}, {0xc001039008?, 0x0?, 0x3bb1060?}, {0x27fc198, 0xc0052425f0}, {0x7f0b706712f8, 0xc000355ae0}, {0x283e2d0, ...}, ...)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:892 +0x2b3
+k8s.io/client-go/tools/cache.handleWatch({0x2815510?, 0xc0007cbce0?}, {0xc001039008?, 0x0?, 0x3bb1060?}, {0x27fc198?, 0xc0052425f0?}, {0x7f0b706712f8?, 0xc000355ae0?}, {0x283e2d0, ...}, ...)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:850 +0xea
+k8s.io/client-go/tools/cache.(*Reflector).watch(0xc000134960, {0x2815510, 0xc0007cbce0}, {0x27fc198, 0xc0052425f0}, 0xc0001582a0)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:542 +0x60e
+k8s.io/client-go/tools/cache.(*Reflector).watchWithResync(0xc000134960, {0x2815510, 0xc0007cbce0}, {0x0, 0x0})
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:482 +0x186
+k8s.io/client-go/tools/cache.(*Reflector).ListAndWatchWithContext(0xc000134960, {0x2815510, 0xc0007cbce0})
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:437 +0x3f2
+k8s.io/client-go/tools/cache.(*Reflector).RunWithContext.func1()
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:360 +0x2e
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1({0x0?, 0x0?})
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:233 +0x13
+k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext.func1({0x2815510?, 0xc0007cbce0?}, 0x41c800?)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:255 +0x51
+k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext({0x2815510, 0xc0007cbce0}, 0xc0006f5ea8, {0x27f0f40, 0xc000377c70}, 0x1)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:256 +0xe5
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x281a1e0?, {0x27f0f40?, 0xc000377c70?}, 0x72?, 0x12?)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:233 +0x46
+k8s.io/client-go/tools/cache.(*Reflector).RunWithContext(0xc000134960, {0x2815510, 0xc0007cbce0})
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:359 +0x22b
+k8s.io/client-go/tools/cache.(*controller).RunWithContext.(*Group).StartWithContext.func3()
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:63 +0x1f
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:72 +0x4c
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 160
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:70 +0x73
+
+goroutine 261 [select, 8118 minutes]:
+context.(*cancelCtx).propagateCancel.func2()
+	/usr/local/go/src/context/context.go:523 +0x98
+created by context.(*cancelCtx).propagateCancel in goroutine 218
+	/usr/local/go/src/context/context.go:522 +0x409
+
+goroutine 727149 [select]:
+github.com/ardikabs/hibernator/internal/notification.(*Dispatcher).workerFactory-fm.(*Dispatcher).workerFactory.func1({0x2815270, 0xc002b515e0})
+	/workspace/internal/notification/dispatcher.go:345 +0x2ce
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f560, {0x2815270, 0xc002b515e0}, {{{0xc004e6e570, 0x11}, {0xc004e6e558, 0x11}}, {0xc00054fce0, 0x8}, {{0xc002450b40, ...}, ...}, ...}, ...)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c7
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 726460
+	/workspace/pkg/keyedworker/pool.go:312 +0x2c7
+
+goroutine 280 [chan receive]:
+k8s.io/client-go/tools/cache.(*processorListener).run(0xc00053a320)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/shared_informer.go:1062 +0x4e
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:72 +0x4c
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 192
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:70 +0x73
+
+goroutine 726415 [select, 8 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/status.(*UpdateProcessor[...].func3.1()
+	/workspace/pkg/keyedworker/handler.go:64 +0x191
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283efe0, {0x2815270, 0xc00223a0f0}, {{0xc004788b40, 0x92ad28?}, {0xc00463db80?, 0x0?}}, 0xc0016b0e70?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 726413
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 200 [select]:
+github.com/telepresenceio/watchable.(*Map[...]).coalesce(0x28487c0, {0x2815270, 0xc00052bc20}, 0xc00021cbe0, 0xc0000af030, 0xc0000af0a0, 0xc0000ad500)
+	/go/pkg/mod/github.com/telepresenceio/watchable@v0.0.0-20220726211108-9bb86f92afa7/map.go:382 +0x72c
+created by github.com/telepresenceio/watchable.(*Map[...]).SubscribeSubset in goroutine 196
+	/go/pkg/mod/github.com/telepresenceio/watchable@v0.0.0-20220726211108-9bb86f92afa7/map.go:281 +0x145
+
+goroutine 201 [chan receive, 8119 minutes]:
+github.com/ardikabs/hibernator/internal/message.HandleSubscription[...].func1()
+	/workspace/internal/message/watchutil.go:49 +0x15f
+created by github.com/ardikabs/hibernator/internal/message.HandleSubscription[...] in goroutine 196
+	/workspace/internal/message/watchutil.go:48 +0x2b0
+
+goroutine 202 [chan receive, 8119 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/status.(*UpdateProcessor[...]).Start(0x282b060, {0x2815270, 0xc00052bc20})
+	/workspace/internal/provider/processor/status/processor.go:157 +0x245
+sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.func1(0xc000200380)
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/runnable_group.go:226 +0xbf
+created by sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile in goroutine 167
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/runnable_group.go:210 +0x191
+
+goroutine 203 [select]:
+github.com/ardikabs/hibernator/internal/message.HandleSubscription[...]({0x2815270, 0xc00052bc20}, {{0x281a520, 0xc0000ad590?}, 0x7f0b70684de0?}, {{0x247bdaf, 0x16}, {0x247bdc5, 0x16}}, 0xc0000af1f0?, ...)
+	/workspace/internal/message/watchutil.go:58 +0x379
+github.com/ardikabs/hibernator/internal/provider/processor/notification.(*LifecycleProcessor).Start(0xc000112370, {0x2815270, 0xc00052bc20})
+	/workspace/internal/provider/processor/notification/lifecycle.go:83 +0x18e
+sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.func1(0xc0002003c0)
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/runnable_group.go:226 +0xbf
+created by sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile in goroutine 167
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/runnable_group.go:210 +0x191
+
+goroutine 244 [sync.Cond.Wait]:
+sync.runtime_notifyListWait(0xc000355ce8, 0x4b9)
+	/usr/local/go/src/runtime/sema.go:606 +0x159
+sync.(*Cond).Wait(0xc0049f10e0?)
+	/usr/local/go/src/sync/cond.go:71 +0x73
+k8s.io/client-go/tools/cache.(*RealFIFO).Pop(0xc000355cc0, 0xc000311300)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/the_real_fifo.go:207 +0x8b
+k8s.io/client-go/tools/cache.(*controller).processLoop(0xc000314580, {0x2815510, 0xc00030a690})
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/controller.go:211 +0x5f
+k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext.func1({0x2815510?, 0xc00030a690?}, 0xc00031ede0?)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:255 +0x51
+k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext({0x2815510, 0xc00030a690}, 0xc0007add70, {0x27f0f20, 0xc00031ede0}, 0x1)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:256 +0xe5
+k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext({0x2815510, 0xc00030a690}, 0xc000384d70, 0x3b9aca00, 0x0, 0x1)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:223 +0x8f
+k8s.io/apimachinery/pkg/util/wait.UntilWithContext(...)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:172
+k8s.io/client-go/tools/cache.(*controller).RunWithContext(0xc000314580, {0x2815510, 0xc00030a690})
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/controller.go:183 +0x418
+k8s.io/client-go/tools/cache.(*sharedIndexInformer).RunWithContext(0xc0005c84d0, {0x2815510, 0xc00030a690})
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/shared_informer.go:587 +0x39a
+k8s.io/client-go/tools/cache.(*sharedIndexInformer).Run(0x2817ae0?, 0xc000384f70?)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/shared_informer.go:526 +0x1d
+sigs.k8s.io/controller-runtime/pkg/cache/internal.(*Cache).Start(0xc0000fd730, 0xc0005d34c0?)
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/cache/internal/informers.go:108 +0x72
+sigs.k8s.io/controller-runtime/pkg/cache/internal.(*Informers).startInformerLocked.func1()
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/cache/internal/informers.go:242 +0x75
+created by sigs.k8s.io/controller-runtime/pkg/cache/internal.(*Informers).startInformerLocked in goroutine 192
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/cache/internal/informers.go:240 +0x87
+
+goroutine 205 [select]:
+github.com/telepresenceio/watchable.(*Map[...]).coalesce(0x2848400, {0x2815270, 0xc00052bc20}, 0xc00021cc50, 0xc0000af180, 0xc0000af1f0, 0xc0000ad620)
+	/go/pkg/mod/github.com/telepresenceio/watchable@v0.0.0-20220726211108-9bb86f92afa7/map.go:382 +0x755
+created by github.com/telepresenceio/watchable.(*Map[...]).SubscribeSubset in goroutine 203
+	/go/pkg/mod/github.com/telepresenceio/watchable@v0.0.0-20220726211108-9bb86f92afa7/map.go:281 +0x145
+
+goroutine 206 [chan receive, 8119 minutes]:
+github.com/ardikabs/hibernator/internal/message.HandleSubscription[...].func1()
+	/workspace/internal/message/watchutil.go:49 +0x15f
+created by github.com/ardikabs/hibernator/internal/message.HandleSubscription[...] in goroutine 203
+	/workspace/internal/message/watchutil.go:48 +0x2b0
+
+goroutine 267 [select]:
+k8s.io/client-go/tools/cache.(*processorListener).pop(0xc0008739a0)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/shared_informer.go:1031 +0x129
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:72 +0x4c
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 213
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:70 +0x73
+
+goroutine 224 [select, 8119 minutes]:
+reflect.rselect({0xc0006e6700, 0x3, 0x24776a1?})
+	/usr/local/go/src/runtime/select.go:616 +0x3ce
+reflect.Select({0xc000314370?, 0x3, 0x1a7ed20?})
+	/usr/local/go/src/reflect/value.go:2949 +0x5ca
+sigs.k8s.io/controller-runtime/pkg/internal/syncs.MergeChans[...].func2()
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/internal/syncs/syncs.go:34 +0x4f
+created by sigs.k8s.io/controller-runtime/pkg/internal/syncs.MergeChans[...] in goroutine 222
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/internal/syncs/syncs.go:32 +0x3cc
+
+goroutine 231 [select, 8119 minutes]:
+reflect.rselect({0xc0007f2f00, 0x3, 0x0?})
+	/usr/local/go/src/runtime/select.go:616 +0x3ce
+reflect.Select({0xc0003144d0?, 0x3, 0x0?})
+	/usr/local/go/src/reflect/value.go:2949 +0x5ca
+sigs.k8s.io/controller-runtime/pkg/internal/syncs.MergeChans[...].func2()
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/internal/syncs/syncs.go:34 +0x4f
+created by sigs.k8s.io/controller-runtime/pkg/internal/syncs.MergeChans[...] in goroutine 244
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/internal/syncs/syncs.go:32 +0x3cc
+
+goroutine 226 [chan receive, 8119 minutes]:
+k8s.io/client-go/tools/cache.(*sharedProcessor).run(0xc000377e00, {0x2815270, 0xc000377ea0})
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/shared_informer.go:893 +0x65
+k8s.io/client-go/tools/cache.(*sharedIndexInformer).RunWithContext.(*Group).StartWithContext.func4()
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:63 +0x1f
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:72 +0x4c
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 222
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:70 +0x73
+
+goroutine 227 [chan receive, 8119 minutes]:
+k8s.io/client-go/tools/cache.(*controller).RunWithContext.func1()
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/controller.go:151 +0x2c
+created by k8s.io/client-go/tools/cache.(*controller).RunWithContext in goroutine 222
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/controller.go:150 +0xdf
+
+goroutine 228 [select]:
+k8s.io/client-go/tools/cache.handleAnyWatch({0x2815510, 0xc00030a2a0}, {0xc00249e460?, 0x0?, 0x3bb1060?}, {0x27fc198, 0xc00045b9a0}, {0x7f0b706712f8, 0xc000355c20}, {0x283e2d0, ...}, ...)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:892 +0x2b3
+k8s.io/client-go/tools/cache.handleWatch({0x2815510?, 0xc00030a2a0?}, {0xc00249e460?, 0x0?, 0x3bb1060?}, {0x27fc198?, 0xc00045b9a0?}, {0x7f0b706712f8?, 0xc000355c20?}, {0x283e2d0, ...}, ...)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:850 +0xea
+k8s.io/client-go/tools/cache.(*Reflector).watch(0xc000134b40, {0x2815510, 0xc00030a2a0}, {0x27fc198, 0xc00045b9a0}, 0xc0047917a0)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:542 +0x60e
+k8s.io/client-go/tools/cache.(*Reflector).watchWithResync(0xc000134b40, {0x2815510, 0xc00030a2a0}, {0x0, 0x0})
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:482 +0x186
+k8s.io/client-go/tools/cache.(*Reflector).ListAndWatchWithContext(0xc000134b40, {0x2815510, 0xc00030a2a0})
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:437 +0x3f2
+k8s.io/client-go/tools/cache.(*Reflector).RunWithContext.func1()
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:360 +0x2e
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1({0x1217b16?, 0xc0034075e0?})
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:233 +0x13
+k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext.func1({0x2815510?, 0xc00030a2a0?}, 0x41c800?)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:255 +0x51
+k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext({0x2815510, 0xc00030a2a0}, 0xc0005b5ea8, {0x27f0f40, 0xc000377ef0}, 0x1)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:256 +0xe5
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x281a1e0?, {0x27f0f40?, 0xc000377ef0?}, 0x72?, 0x12?)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:233 +0x46
+k8s.io/client-go/tools/cache.(*Reflector).RunWithContext(0xc000134b40, {0x2815510, 0xc00030a2a0})
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:359 +0x22b
+k8s.io/client-go/tools/cache.(*controller).RunWithContext.(*Group).StartWithContext.func3()
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:63 +0x1f
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:72 +0x4c
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 222
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:70 +0x73
+
+goroutine 246 [sync.Cond.Wait]:
+sync.runtime_notifyListWait(0xc00003c2a8, 0xe7d)
+	/usr/local/go/src/runtime/sema.go:606 +0x159
+sync.(*Cond).Wait(0xc0049f11e0?)
+	/usr/local/go/src/sync/cond.go:71 +0x73
+k8s.io/client-go/tools/cache.(*RealFIFO).Pop(0xc00003c280, 0xc00021cdc0)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/the_real_fifo.go:207 +0x8b
+k8s.io/client-go/tools/cache.(*controller).processLoop(0xc0005c8840, {0x2815510, 0xc0000af500})
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/controller.go:211 +0x5f
+k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext.func1({0x2815510?, 0xc0000af500?}, 0xc00066c210?)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:255 +0x51
+k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext({0x2815510, 0xc0000af500}, 0xc001f0dd70, {0x27f0f20, 0xc00066c210}, 0x1)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:256 +0xe5
+k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext({0x2815510, 0xc0000af500}, 0xc0004bbd70, 0x3b9aca00, 0x0, 0x1)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:223 +0x8f
+k8s.io/apimachinery/pkg/util/wait.UntilWithContext(...)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:172
+k8s.io/client-go/tools/cache.(*controller).RunWithContext(0xc0005c8840, {0x2815510, 0xc0000af500})
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/controller.go:183 +0x418
+k8s.io/client-go/tools/cache.(*sharedIndexInformer).RunWithContext(0xc0005c86e0, {0x2815510, 0xc0000af500})
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/shared_informer.go:587 +0x39a
+k8s.io/client-go/tools/cache.(*sharedIndexInformer).Run(0x2817ae0?, 0xc0004bbf70?)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/shared_informer.go:526 +0x1d
+sigs.k8s.io/controller-runtime/pkg/cache/internal.(*Cache).Start(0xc0000fdb90, 0xc0005d34c0?)
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/cache/internal/informers.go:108 +0x72
+sigs.k8s.io/controller-runtime/pkg/cache/internal.(*Informers).startInformerLocked.func1()
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/cache/internal/informers.go:242 +0x75
+created by sigs.k8s.io/controller-runtime/pkg/cache/internal.(*Informers).startInformerLocked in goroutine 213
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/cache/internal/informers.go:240 +0x87
+
+goroutine 208 [chan receive, 8119 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/status.(*UpdateProcessor[...]).Start(0x282b100, {0x2815270, 0xc00052bc20})
+	/workspace/internal/provider/processor/status/processor.go:157 +0x245
+sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.func1(0xc000200400)
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/runnable_group.go:226 +0xbf
+created by sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile in goroutine 167
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/runnable_group.go:210 +0x191
+
+goroutine 241 [chan receive, 8119 minutes]:
+github.com/ardikabs/hibernator/internal/notification.(*Dispatcher).Start(0xc000018480, {0x2815270, 0xc00052bc20})
+	/workspace/internal/notification/dispatcher.go:277 +0x2b7
+sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.func1(0xc000200440)
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/runnable_group.go:226 +0xbf
+created by sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile in goroutine 167
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/manager/runnable_group.go:210 +0x191
+
+goroutine 726407 [select]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).loop(0xc004724780, {0x2815270, 0xc000c73bd0})
+	/workspace/internal/provider/processor/plan/timer.go:203 +0x177
+created by github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).Start in goroutine 726406
+	/workspace/internal/provider/processor/plan/timer.go:174 +0xd0
+
+goroutine 262 [select, 374 minutes]:
+k8s.io/client-go/tools/cache.(*Reflector).startResync(0xc000134960, {0x2815270, 0xc00023c2d0}, 0xc0001582a0)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:450 +0x12d
+k8s.io/client-go/tools/cache.(*Reflector).watchWithResync.func2()
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:480 +0x25
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:72 +0x4c
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 218
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:70 +0x73
+
+goroutine 252 [select]:
+k8s.io/client-go/tools/cache.handleAnyWatch({0x2815510, 0xc0000af500}, {0xc003c16e18?, 0x0?, 0x3bb1060?}, {0x27fc198, 0xc00425fc70}, {0x7f0b706712f8, 0xc00003c280}, {0x283e2d0, ...}, ...)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:892 +0x2b3
+k8s.io/client-go/tools/cache.handleWatch({0x2815510?, 0xc0000af500?}, {0xc003c16e18?, 0x0?, 0x3bb1060?}, {0x27fc198?, 0xc00425fc70?}, {0x7f0b706712f8?, 0xc00003c280?}, {0x283e2d0, ...}, ...)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:850 +0xea
+k8s.io/client-go/tools/cache.(*Reflector).watch(0xc0005722d0, {0x2815510, 0xc0000af500}, {0x27fc198, 0xc00425fc70}, 0xc00014a850)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:542 +0x60e
+k8s.io/client-go/tools/cache.(*Reflector).watchWithResync(0xc0005722d0, {0x2815510, 0xc0000af500}, {0x0, 0x0})
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:482 +0x186
+k8s.io/client-go/tools/cache.(*Reflector).ListAndWatchWithContext(0xc0005722d0, {0x2815510, 0xc0000af500})
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:437 +0x3f2
+k8s.io/client-go/tools/cache.(*Reflector).RunWithContext.func1()
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:360 +0x2e
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1({0x0?, 0x0?})
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:233 +0x13
+k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext.func1({0x2815510?, 0xc0000af500?}, 0x41c800?)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:255 +0x51
+k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext({0x2815510, 0xc0000af500}, 0xc00067dea8, {0x27f0f40, 0xc000488d70}, 0x1)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:256 +0xe5
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x281a1e0?, {0x27f0f40?, 0xc000488d70?}, 0x72?, 0x12?)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:233 +0x46
+k8s.io/client-go/tools/cache.(*Reflector).RunWithContext(0xc0005722d0, {0x2815510, 0xc0000af500})
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:359 +0x22b
+k8s.io/client-go/tools/cache.(*controller).RunWithContext.(*Group).StartWithContext.func3()
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:63 +0x1f
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:72 +0x4c
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 246
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:70 +0x73
+
+goroutine 727392 [select, 8 minutes]:
+google.golang.org/grpc/internal/transport.(*http2Server).keepalive(0xc003cc3040)
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/internal/transport/http2_server.go:1197 +0x1ea
+created by google.golang.org/grpc/internal/transport.NewServerTransport in goroutine 727390
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/internal/transport/http2_server.go:357 +0x18dd
+
+goroutine 233 [chan receive, 8119 minutes]:
+k8s.io/client-go/tools/cache.(*sharedProcessor).run(0xc000488b40, {0x2815270, 0xc00023c0f0})
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/shared_informer.go:893 +0x65
+k8s.io/client-go/tools/cache.(*sharedIndexInformer).RunWithContext.(*Group).StartWithContext.func4()
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:63 +0x1f
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:72 +0x4c
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 244
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:70 +0x73
+
+goroutine 234 [chan receive, 8119 minutes]:
+k8s.io/client-go/tools/cache.(*controller).RunWithContext.func1()
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/controller.go:151 +0x2c
+created by k8s.io/client-go/tools/cache.(*controller).RunWithContext in goroutine 244
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/controller.go:150 +0xdf
+
+goroutine 235 [select]:
+k8s.io/client-go/tools/cache.handleAnyWatch({0x2815510, 0xc00030a690}, {0xc003de8378?, 0x0?, 0x3bb1060?}, {0x27fc198, 0xc004ded2c0}, {0x7f0b706712f8, 0xc000355cc0}, {0x283e2d0, ...}, ...)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:892 +0x2b3
+k8s.io/client-go/tools/cache.handleWatch({0x2815510?, 0xc00030a690?}, {0xc003de8378?, 0x0?, 0x3bb1060?}, {0x27fc198?, 0xc004ded2c0?}, {0x7f0b706712f8?, 0xc000355cc0?}, {0x283e2d0, ...}, ...)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:850 +0xea
+k8s.io/client-go/tools/cache.(*Reflector).watch(0xc000134d20, {0x2815510, 0xc00030a690}, {0x27fc198, 0xc004ded2c0}, 0xc003604540)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:542 +0x60e
+k8s.io/client-go/tools/cache.(*Reflector).watchWithResync(0xc000134d20, {0x2815510, 0xc00030a690}, {0x0, 0x0})
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:482 +0x186
+k8s.io/client-go/tools/cache.(*Reflector).ListAndWatchWithContext(0xc000134d20, {0x2815510, 0xc00030a690})
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:437 +0x3f2
+k8s.io/client-go/tools/cache.(*Reflector).RunWithContext.func1()
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:360 +0x2e
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1({0x1217b16?, 0xc000221880?})
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:233 +0x13
+k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext.func1({0x2815510?, 0xc00030a690?}, 0x41c800?)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:255 +0x51
+k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext({0x2815510, 0xc00030a690}, 0xc0005b7ea8, {0x27f0f40, 0xc00023c140}, 0x1)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:256 +0xe5
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x281a1e0?, {0x27f0f40?, 0xc00023c140?}, 0x72?, 0x12?)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:233 +0x46
+k8s.io/client-go/tools/cache.(*Reflector).RunWithContext(0xc000134d20, {0x2815510, 0xc00030a690})
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:359 +0x22b
+k8s.io/client-go/tools/cache.(*controller).RunWithContext.(*Group).StartWithContext.func3()
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:63 +0x1f
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:72 +0x4c
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 244
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:70 +0x73
+
+goroutine 239 [select, 246 minutes]:
+k8s.io/client-go/tools/cache.(*Reflector).startResync(0xc0005722d0, {0x2815270, 0xc00023c4b0}, 0xc00014a850)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:450 +0x12d
+k8s.io/client-go/tools/cache.(*Reflector).watchWithResync.func2()
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:480 +0x25
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:72 +0x4c
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 252
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:70 +0x73
+
+goroutine 726460 [select]:
+github.com/ardikabs/hibernator/internal/provider/processor/status.(*UpdateProcessor[...].func3.1()
+	/workspace/pkg/keyedworker/handler.go:64 +0x191
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283efe0, {0x2815270, 0xc00425e140}, {{0xc005333b48, 0x92ad28?}, {0xc005333bc0?, 0xc001890e10?}}, 0xc002a955f0?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 726458
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 730735 [select, 7 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2.1()
+	/workspace/internal/provider/processor/requeue/processor.go:116 +0x111
+created by github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2 in goroutine 183
+	/workspace/internal/provider/processor/requeue/processor.go:112 +0x78d
+
+goroutine 264 [chan receive]:
+k8s.io/client-go/tools/cache.(*processorListener).run(0xc000873900)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/shared_informer.go:1062 +0x4e
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:72 +0x4c
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 211
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:70 +0x73
+
+goroutine 265 [select]:
+k8s.io/client-go/tools/cache.(*processorListener).pop(0xc000873900)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/shared_informer.go:1031 +0x129
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:72 +0x4c
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 211
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:70 +0x73
+
+goroutine 278 [chan receive]:
+k8s.io/client-go/tools/cache.(*processorListener).run(0xc00053a0a0)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/shared_informer.go:1062 +0x4e
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:72 +0x4c
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 159
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:70 +0x73
+
+goroutine 279 [select]:
+k8s.io/client-go/tools/cache.(*processorListener).pop(0xc00053a0a0)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/shared_informer.go:1031 +0x129
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:72 +0x4c
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 159
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:70 +0x73
+
+goroutine 726855 [select, 3 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*Worker).run(0xc002545500, {0x2815270, 0xc001e7af00})
+	/workspace/internal/provider/processor/plan/worker.go:122 +0x6fe
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f6c0, {0x2815270, 0xc001e7af00}, {{0xc004b1d728, 0x92ad28?}, {0xc0055060a0?, 0xc002520ae0?}}, 0xc0018f1a10?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 182
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 726402 [select, 9 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2.1()
+	/workspace/internal/provider/processor/requeue/processor.go:116 +0x111
+created by github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2 in goroutine 183
+	/workspace/internal/provider/processor/requeue/processor.go:112 +0x78d
+
+goroutine 726458 [select]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*Worker).run(0xc004439d00, {0x2815270, 0xc00425e050})
+	/workspace/internal/provider/processor/plan/worker.go:122 +0x6fe
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f6c0, {0x2815270, 0xc00425e050}, {{0xc005333b48, 0x92ad28?}, {0xc005333bc0?, 0xc001890e10?}}, 0xc001209590?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 182
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 726826 [select]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).loop(0xc002cce5a0, {0x2815270, 0xc004c92ff0})
+	/workspace/internal/provider/processor/plan/timer.go:203 +0x177
+created by github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).Start in goroutine 726825
+	/workspace/internal/provider/processor/plan/timer.go:174 +0xd0
+
+goroutine 726438 [select, 7 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/status.(*UpdateProcessor[...].func3.1()
+	/workspace/pkg/keyedworker/handler.go:64 +0x191
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283efe0, {0x2815270, 0xc0004523c0}, {{0xc002f7fea8, 0x453472?}, {0xc003c80090?, 0x8607c5?}}, 0xc00144d770?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 726436
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 733279 [select]:
+google.golang.org/grpc/internal/transport.(*recvBufferReader).readMessageHeader(0xc0043ab5e0, {0xc004b88550, 0x5, 0x5})
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/internal/transport/transport.go:176 +0x9e
+google.golang.org/grpc/internal/transport.(*recvBufferReader).ReadMessageHeader(0xc0043ab5e0, {0xc004b88550?, 0xc001883520?, 0xc004eb1bc0?})
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/internal/transport/transport.go:145 +0x77
+google.golang.org/grpc/internal/transport.(*transportReader).ReadMessageHeader(0xc00435fc40, {0xc004b88550?, 0x23991e0?, 0xc0049f0920?})
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/internal/transport/transport.go:417 +0x25
+google.golang.org/grpc/internal/transport.(*Stream).ReadMessageHeader(0xc003b3e990, {0xc004b88550, 0x5, 0x5})
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/internal/transport/transport.go:360 +0x9e
+google.golang.org/grpc.(*parser).recvMsg(0xc004b88540, 0x400000)
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/rpc_util.go:659 +0x3b
+google.golang.org/grpc.recvAndDecompress(0xc004b88540, {0x27f3e40, 0xc004eb1bc0}, {0x0, 0x0}, 0x400000, 0x0, {0x0, 0x0}, 0x1)
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/rpc_util.go:819 +0x97
+google.golang.org/grpc.recv(0x5?, {0x7f0b70487750, 0x3bd39e0}, {0x27f3e40?, 0xc004eb1bc0?}, {0x0?, 0x0?}, {0x22bccc0, 0xc004c51e30}, 0x400000, ...)
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/rpc_util.go:902 +0xab
+google.golang.org/grpc.(*serverStream).RecvMsg(0xc003a82a80, {0x22bccc0, 0xc004c51e30})
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/stream.go:1760 +0x192
+google.golang.org/grpc.(*GenericServerStream[...]).Recv(0x2822200)
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/stream_interfaces.go:234 +0x4e
+github.com/ardikabs/hibernator/internal/streaming/server.(*ExecutionServiceServer).StreamLogs(0xc00053cbd0, {0x2822190, 0xc0033e8440})
+	/workspace/internal/streaming/server/service.go:103 +0x127
+github.com/ardikabs/hibernator/api/streaming/v1alpha1._ExecutionService_StreamLogs_Handler({0x2318f20?, 0xc00053cbd0}, {0x281a8c8, 0xc00435fe80})
+	/workspace/api/streaming/v1alpha1/execution_grpc.pb.go:162 +0xd8
+github.com/ardikabs/hibernator/internal/streaming/server.NewServer.GRPCStreamInterceptor.func3({0x2318f20, 0xc00053cbd0}, {0x281b518, 0xc003a82a80}, 0xc004bc9f68, 0x25f1e08)
+	/workspace/internal/streaming/auth/interceptor.go:139 +0x2b9
+google.golang.org/grpc.(*Server).processStreamingRPC(0xc000338200, {0x2815238, 0xc004b884e0}, 0xc004eb1bc0, 0xc0003e96b0, 0x3b84120, 0x0)
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/server.go:1702 +0x1253
+google.golang.org/grpc.(*Server).handleStream(0xc000338200, {0x2816060, 0xc001883520}, 0xc004eb1bc0)
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/server.go:1819 +0xb54
+google.golang.org/grpc.(*Server).serveStreams.func2.1()
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/server.go:1035 +0x7f
+created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 733334
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/server.go:1046 +0x11d
+
+goroutine 726454 [select, 8 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/status.(*UpdateProcessor[...].func3.1()
+	/workspace/pkg/keyedworker/handler.go:64 +0x191
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283efe0, {0x2815270, 0xc0043d5630}, {{0xc0035d7cc8, 0x453472?}, {0xc0035d7d40?, 0x0?}}, 0xc004b89e30?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 726452
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 732673 [IO wait]:
+internal/poll.runtime_pollWait(0x7f0b7046ae00, 0x72)
+	/usr/local/go/src/runtime/netpoll.go:351 +0x85
+internal/poll.(*pollDesc).wait(0xc00281a780?, 0xc000da2000?, 0x0)
+	/usr/local/go/src/internal/poll/fd_poll_runtime.go:84 +0x27
+internal/poll.(*pollDesc).waitRead(...)
+	/usr/local/go/src/internal/poll/fd_poll_runtime.go:89
+internal/poll.(*FD).Read(0xc00281a780, {0xc000da2000, 0x1000, 0x1000})
+	/usr/local/go/src/internal/poll/fd_unix.go:165 +0x279
+net.(*netFD).Read(0xc00281a780, {0xc000da2000?, 0x16?, 0x47e86c?})
+	/usr/local/go/src/net/fd_posix.go:68 +0x25
+net.(*conn).Read(0xc0042909d0, {0xc000da2000?, 0x7f0b705d4010?, 0x7f0bb7485108?})
+	/usr/local/go/src/net/net.go:196 +0x45
+crypto/tls.(*atLeastReader).Read(0xc00156a498, {0xc000da2000?, 0xf?, 0x5?})
+	/usr/local/go/src/crypto/tls/conn.go:819 +0x3b
+bytes.(*Buffer).ReadFrom(0xc002c082a8, {0x27ef560, 0xc00156a498})
+	/usr/local/go/src/bytes/buffer.go:217 +0x98
+crypto/tls.(*Conn).readFromUntil(0xc002c08008, {0x27ef680, 0xc0042909d0}, 0xc0004bb9a8?)
+	/usr/local/go/src/crypto/tls/conn.go:841 +0xde
+crypto/tls.(*Conn).readRecordOrCCS(0xc002c08008, 0x0)
+	/usr/local/go/src/crypto/tls/conn.go:630 +0x3db
+crypto/tls.(*Conn).readRecord(...)
+	/usr/local/go/src/crypto/tls/conn.go:592
+crypto/tls.(*Conn).Read(0xc002c08008, {0xc000ff4000, 0x1000, 0xc0004bbca8?})
+	/usr/local/go/src/crypto/tls/conn.go:1397 +0x145
+bufio.(*Reader).Read(0xc0020dc780, {0xc001b30ac0, 0x9, 0x414a40?})
+	/usr/local/go/src/bufio/bufio.go:245 +0x197
+io.ReadAtLeast({0x27edea0, 0xc0020dc780}, {0xc001b30ac0, 0x9, 0x9}, 0x9)
+	/usr/local/go/src/io/io.go:335 +0x8e
+io.ReadFull(...)
+	/usr/local/go/src/io/io.go:354
+net/http.http2readFrameHeader({0xc001b30ac0, 0x9, 0x84ad5f?}, {0x27edea0?, 0xc0020dc780?})
+	/usr/local/go/src/net/http/h2_bundle.go:1811 +0x65
+net/http.(*http2Framer).ReadFrame(0xc001b30a80)
+	/usr/local/go/src/net/http/h2_bundle.go:2078 +0x7d
+net/http.(*http2clientConnReadLoop).run(0xc0004bbfa8)
+	/usr/local/go/src/net/http/h2_bundle.go:9539 +0xda
+net/http.(*http2ClientConn).readLoop(0xc0015d8a80)
+	/usr/local/go/src/net/http/h2_bundle.go:9408 +0x79
+created by net/http.(*http2Transport).newClientConn in goroutine 732672
+	/usr/local/go/src/net/http/h2_bundle.go:8192 +0xde5
+
+goroutine 734483 [select]:
+github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2.1()
+	/workspace/internal/provider/processor/requeue/processor.go:116 +0x111
+created by github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2 in goroutine 183
+	/workspace/internal/provider/processor/requeue/processor.go:112 +0x78d
+
+goroutine 727524 [select, 7 minutes]:
+github.com/ardikabs/hibernator/internal/notification.(*Dispatcher).workerFactory-fm.(*Dispatcher).workerFactory.func1({0x2815270, 0xc001ea3450})
+	/workspace/internal/notification/dispatcher.go:345 +0x2ce
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f560, {0x2815270, 0xc001ea3450}, {{{0xc004b94ab0, 0x11}, {0xc004b94a98, 0x14}}, {0xc000ff3eb0, 0x8}, {{0xc002450b40, ...}, ...}, ...}, ...)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c7
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 726454
+	/workspace/pkg/keyedworker/pool.go:312 +0x2c7
+
+goroutine 726464 [select, 9 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2.1()
+	/workspace/internal/provider/processor/requeue/processor.go:116 +0x111
+created by github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2 in goroutine 183
+	/workspace/internal/provider/processor/requeue/processor.go:112 +0x78d
+
+goroutine 727303 [select]:
+google.golang.org/grpc/internal/transport.(*controlBuffer).get(0xc00517e280, 0x1)
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/internal/transport/controlbuf.go:412 +0x108
+google.golang.org/grpc/internal/transport.(*loopyWriter).run(0xc002b75200)
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/internal/transport/controlbuf.go:575 +0x78
+google.golang.org/grpc/internal/transport.NewServerTransport.func2()
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/internal/transport/http2_server.go:336 +0xdc
+created by google.golang.org/grpc/internal/transport.NewServerTransport in goroutine 727302
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/internal/transport/http2_server.go:334 +0x189b
+
+goroutine 726851 [select, 7 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/status.(*UpdateProcessor[...].func3.1()
+	/workspace/pkg/keyedworker/handler.go:64 +0x191
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283efe0, {0x2815270, 0xc001e7a5a0}, {{0xc003e1d128, 0x92ad28?}, {0xc0022571f0?, 0xc002738d20?}}, 0xc0000ad020?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 726849
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 732526 [sync.Cond.Wait]:
+sync.runtime_notifyListWait(0xc004d35848, 0x23)
+	/usr/local/go/src/runtime/sema.go:606 +0x159
+sync.(*Cond).Wait(0x27ed040?)
+	/usr/local/go/src/sync/cond.go:71 +0x73
+golang.org/x/net/http2.(*pipe).Read(0xc004d35830, {0xc002190001, 0xfdff, 0xfdff})
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/pipe.go:76 +0xdb
+golang.org/x/net/http2.transportResponseBody.Read({0x0?}, {0xc002190001?, 0x41c8d4?, 0x0?})
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/transport.go:2560 +0x59
+encoding/json.(*Decoder).refill(0xc004ed1040)
+	/usr/local/go/src/encoding/json/stream.go:167 +0x188
+encoding/json.(*Decoder).readValue(0xc004ed1040)
+	/usr/local/go/src/encoding/json/stream.go:142 +0x85
+encoding/json.(*Decoder).Decode(0xc004ed1040, {0x20b2220, 0xc0045364e0})
+	/usr/local/go/src/encoding/json/stream.go:65 +0x75
+k8s.io/apimachinery/pkg/util/framer.(*jsonFrameReader).Read(0xc0024300f0, {0xc0023be000, 0x10000, 0x14000})
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/framer/framer.go:151 +0x15c
+k8s.io/apimachinery/pkg/runtime/serializer/streaming.(*decoder).Decode(0xc004ded270, 0x0, {0x27fbf90, 0xc004840400})
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/runtime/serializer/streaming/streaming.go:77 +0xa3
+k8s.io/client-go/rest/watch.(*Decoder).Decode(0xc004e89200)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/rest/watch/decoder.go:49 +0x4b
+k8s.io/apimachinery/pkg/watch.(*StreamWatcher).receive(0xc004ded2c0)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/watch/streamwatcher.go:114 +0xf8
+created by k8s.io/apimachinery/pkg/watch.NewStreamWatcherWithLogger in goroutine 235
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/watch/streamwatcher.go:85 +0x149
+
+goroutine 727145 [select, 3 minutes]:
+github.com/ardikabs/hibernator/internal/notification.(*Dispatcher).workerFactory-fm.(*Dispatcher).workerFactory.func1({0x2815270, 0xc002b51400})
+	/workspace/internal/notification/dispatcher.go:345 +0x2ce
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f560, {0x2815270, 0xc002b51400}, {{{0xc003e2b470, 0x11}, {0xc003e2b458, 0x14}}, {0xc0025a3080, 0x8}, {{0xc002450b40, ...}, ...}, ...}, ...)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c7
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 726509
+	/workspace/pkg/keyedworker/pool.go:312 +0x2c7
+
+goroutine 726587 [select, 8 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2.1()
+	/workspace/internal/provider/processor/requeue/processor.go:116 +0x111
+created by github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2 in goroutine 183
+	/workspace/internal/provider/processor/requeue/processor.go:112 +0x78d
+
+goroutine 726436 [select, 7 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*Worker).run(0xc004a3aa00, {0x2815270, 0xc0004522d0})
+	/workspace/internal/provider/processor/plan/worker.go:122 +0x6fe
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f6c0, {0x2815270, 0xc0004522d0}, {{0xc002f7fea8, 0x92ad28?}, {0xc003c80090?, 0x0?}}, 0xc0018bae40?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 182
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 726857 [select, 3 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/status.(*UpdateProcessor[...].func3.1()
+	/workspace/pkg/keyedworker/handler.go:64 +0x191
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283efe0, {0x2815270, 0xc001e7aff0}, {{0xc004b1d728, 0x92ad28?}, {0xc0055060a0?, 0xc002520ae0?}}, 0xc0019c5dd0?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 726855
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 728535 [select]:
+google.golang.org/grpc/internal/transport.(*recvBufferReader).readMessageHeader(0xc002754320, {0xc002ce5cf0, 0x5, 0x5})
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/internal/transport/transport.go:176 +0x9e
+google.golang.org/grpc/internal/transport.(*recvBufferReader).ReadMessageHeader(0xc002754320, {0xc002ce5cf0?, 0xc002bb31e0?, 0xc0044ed4a0?})
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/internal/transport/transport.go:145 +0x77
+google.golang.org/grpc/internal/transport.(*transportReader).ReadMessageHeader(0xc0033a0de0, {0xc002ce5cf0?, 0x23991e0?, 0xc004a4a9e0?})
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/internal/transport/transport.go:417 +0x25
+google.golang.org/grpc/internal/transport.(*Stream).ReadMessageHeader(0xc0028147e0, {0xc002ce5cf0, 0x5, 0x5})
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/internal/transport/transport.go:360 +0x9e
+google.golang.org/grpc.(*parser).recvMsg(0xc002ce5ce0, 0x400000)
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/rpc_util.go:659 +0x3b
+google.golang.org/grpc.recvAndDecompress(0xc002ce5ce0, {0x27f3e40, 0xc0044ed4a0}, {0x0, 0x0}, 0x400000, 0x0, {0x0, 0x0}, 0x1)
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/rpc_util.go:819 +0x97
+google.golang.org/grpc.recv(0x5?, {0x7f0b70487750, 0x3bd39e0}, {0x27f3e40?, 0xc0044ed4a0?}, {0x0?, 0x0?}, {0x22bccc0, 0xc004b73500}, 0x400000, ...)
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/rpc_util.go:902 +0xab
+google.golang.org/grpc.(*serverStream).RecvMsg(0xc003b73420, {0x22bccc0, 0xc004b73500})
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/stream.go:1760 +0x192
+google.golang.org/grpc.(*GenericServerStream[...]).Recv(0x2822200)
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/stream_interfaces.go:234 +0x4e
+github.com/ardikabs/hibernator/internal/streaming/server.(*ExecutionServiceServer).StreamLogs(0xc00053cbd0, {0x2822190, 0xc0044774d0})
+	/workspace/internal/streaming/server/service.go:103 +0x127
+github.com/ardikabs/hibernator/api/streaming/v1alpha1._ExecutionService_StreamLogs_Handler({0x2318f20?, 0xc00053cbd0}, {0x281a8c8, 0xc0004c3500})
+	/workspace/api/streaming/v1alpha1/execution_grpc.pb.go:162 +0xd8
+github.com/ardikabs/hibernator/internal/streaming/server.NewServer.GRPCStreamInterceptor.func3({0x2318f20, 0xc00053cbd0}, {0x281b518, 0xc003b73420}, 0xc000b4ad38, 0x25f1e08)
+	/workspace/internal/streaming/auth/interceptor.go:139 +0x2b9
+google.golang.org/grpc.(*Server).processStreamingRPC(0xc000338200, {0x2815238, 0xc002ce5c80}, 0xc0044ed4a0, 0xc0003e96b0, 0x3b84120, 0x0)
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/server.go:1702 +0x1253
+google.golang.org/grpc.(*Server).handleStream(0xc000338200, {0x2816060, 0xc002bb31e0}, 0xc0044ed4a0)
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/server.go:1819 +0xb54
+google.golang.org/grpc.(*Server).serveStreams.func2.1()
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/server.go:1035 +0x7f
+created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 728534
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/server.go:1046 +0x11d
+
+goroutine 727272 [select, 7 minutes]:
+github.com/ardikabs/hibernator/internal/notification.(*Dispatcher).workerFactory-fm.(*Dispatcher).workerFactory.func1({0x2815270, 0xc0037a8c80})
+	/workspace/internal/notification/dispatcher.go:345 +0x2ce
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f560, {0x2815270, 0xc0037a8c80}, {{{0xc003766258, 0x11}, {0xc003766240, 0x14}}, {0xc0030cdf20, 0x8}, {{0xc002450b40, ...}, ...}, ...}, ...)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c7
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 726901
+	/workspace/pkg/keyedworker/pool.go:312 +0x2c7
+
+goroutine 726850 [select, 7 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).loop(0xc002b62d20, {0x2815270, 0xc001e7a550})
+	/workspace/internal/provider/processor/plan/timer.go:203 +0x177
+created by github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).Start in goroutine 726849
+	/workspace/internal/provider/processor/plan/timer.go:174 +0xd0
+
+goroutine 21398 [select]:
+k8s.io/client-go/tools/record.(*eventBroadcasterImpl).StartEventWatcher.func1()
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/record/event.go:407 +0xfe
+created by k8s.io/client-go/tools/record.(*eventBroadcasterImpl).StartEventWatcher in goroutine 21373
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/record/event.go:404 +0xb2
+
+goroutine 323 [select, 9 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*Worker).run(0xc001219600, {0x2815270, 0xc000377450})
+	/workspace/internal/provider/processor/plan/worker.go:122 +0x6fe
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f6c0, {0x2815270, 0xc000377450}, {{0xc000438378, 0xc00043a170?}, {0xc00043a170?, 0xc001269080?}}, 0xc001269140?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 182
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 324 [select, 9 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).loop(0xc001600280, {0x2815270, 0xc0003774f0})
+	/workspace/internal/provider/processor/plan/timer.go:203 +0x177
+created by github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).Start in goroutine 323
+	/workspace/internal/provider/processor/plan/timer.go:174 +0xd0
+
+goroutine 325 [select, 8 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*Worker).run(0xc001218800, {0x2815270, 0xc000426050})
+	/workspace/internal/provider/processor/plan/worker.go:122 +0x6fe
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f6c0, {0x2815270, 0xc000426050}, {{0xc000438f30, 0x222c7d7b3a226573?}, {0xc000438f48?, 0x6472612e726f7461?}}, 0xc0016b1740?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 182
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 326 [select, 8 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).loop(0xc000f79c20, {0x2815270, 0xc0004261e0})
+	/workspace/internal/provider/processor/plan/timer.go:203 +0x177
+created by github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).Start in goroutine 325
+	/workspace/internal/provider/processor/plan/timer.go:174 +0xd0
+
+goroutine 726452 [select]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*Worker).run(0xc004439100, {0x2815270, 0xc0043d5540})
+	/workspace/internal/provider/processor/plan/worker.go:122 +0x6fe
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f6c0, {0x2815270, 0xc0043d5540}, {{0xc0035d7cc8, 0x453472?}, {0xc0035d7d40?, 0xc002520ae0?}}, 0xc0010f95c0?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 182
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 727470 [select, 7 minutes]:
+github.com/ardikabs/hibernator/internal/notification.(*Dispatcher).workerFactory-fm.(*Dispatcher).workerFactory.func1({0x2815270, 0xc005242ff0})
+	/workspace/internal/notification/dispatcher.go:345 +0x2ce
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f560, {0x2815270, 0xc005242ff0}, {{{0xc0049b8b70, 0x11}, {0xc0043dcf80, 0x1c}}, {0xc00427e9f0, 0x8}, {{0xc002450b40, ...}, ...}, ...}, ...)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c7
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 726415
+	/workspace/pkg/keyedworker/pool.go:312 +0x2c7
+
+goroutine 727026 [select]:
+github.com/ardikabs/hibernator/internal/notification.(*Dispatcher).workerFactory-fm.(*Dispatcher).workerFactory.func1({0x2815270, 0xc0026d9770})
+	/workspace/internal/notification/dispatcher.go:345 +0x2ce
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f560, {0x2815270, 0xc0026d9770}, {{{0xc002720ab0, 0x11}, {0xc002720a80, 0x11}}, {0xc003f77520, 0x8}, {{0xc002450b40, ...}, ...}, ...}, ...)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c7
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 726418
+	/workspace/pkg/keyedworker/pool.go:312 +0x2c7
+
+goroutine 726518 [select, 8 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).loop(0xc003422d20, {0x2815270, 0xc00425fd60})
+	/workspace/internal/provider/processor/plan/timer.go:203 +0x177
+created by github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).Start in goroutine 726517
+	/workspace/internal/provider/processor/plan/timer.go:174 +0xd0
+
+goroutine 726589 [select]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).loop(0xc002c68140, {0x2815270, 0xc004a73360})
+	/workspace/internal/provider/processor/plan/timer.go:203 +0x177
+created by github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).Start in goroutine 726588
+	/workspace/internal/provider/processor/plan/timer.go:174 +0xd0
+
+goroutine 727317 [select]:
+google.golang.org/grpc/internal/transport.(*recvBufferReader).readMessageHeader(0xc004031770, {0xc0044c4ac0, 0x5, 0x5})
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/internal/transport/transport.go:176 +0x9e
+google.golang.org/grpc/internal/transport.(*recvBufferReader).ReadMessageHeader(0xc004031770, {0xc0044c4ac0?, 0xc001db69c0?, 0xc003d47680?})
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/internal/transport/transport.go:145 +0x77
+google.golang.org/grpc/internal/transport.(*transportReader).ReadMessageHeader(0xc004a1f040, {0xc0044c4ac0?, 0x23991e0?, 0xc0006019c0?})
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/internal/transport/transport.go:417 +0x25
+google.golang.org/grpc/internal/transport.(*Stream).ReadMessageHeader(0xc0006d5050, {0xc0044c4ac0, 0x5, 0x5})
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/internal/transport/transport.go:360 +0x9e
+google.golang.org/grpc.(*parser).recvMsg(0xc0044c4ab0, 0x400000)
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/rpc_util.go:659 +0x3b
+google.golang.org/grpc.recvAndDecompress(0xc0044c4ab0, {0x27f3e40, 0xc003d47680}, {0x0, 0x0}, 0x400000, 0x0, {0x0, 0x0}, 0x1)
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/rpc_util.go:819 +0x97
+google.golang.org/grpc.recv(0x5?, {0x7f0b70487750, 0x3bd39e0}, {0x27f3e40?, 0xc003d47680?}, {0x0?, 0x0?}, {0x22bccc0, 0xc00015afc0}, 0x400000, ...)
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/rpc_util.go:902 +0xab
+google.golang.org/grpc.(*serverStream).RecvMsg(0xc004af8620, {0x22bccc0, 0xc00015afc0})
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/stream.go:1760 +0x192
+google.golang.org/grpc.(*GenericServerStream[...]).Recv(0x2822200)
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/stream_interfaces.go:234 +0x4e
+github.com/ardikabs/hibernator/internal/streaming/server.(*ExecutionServiceServer).StreamLogs(0xc00053cbd0, {0x2822190, 0xc00005f9c0})
+	/workspace/internal/streaming/server/service.go:103 +0x127
+github.com/ardikabs/hibernator/api/streaming/v1alpha1._ExecutionService_StreamLogs_Handler({0x2318f20?, 0xc00053cbd0}, {0x281a8c8, 0xc004488be0})
+	/workspace/api/streaming/v1alpha1/execution_grpc.pb.go:162 +0xd8
+github.com/ardikabs/hibernator/internal/streaming/server.NewServer.GRPCStreamInterceptor.func3({0x2318f20, 0xc00053cbd0}, {0x281b518, 0xc004af8620}, 0xc00107d560, 0x25f1e08)
+	/workspace/internal/streaming/auth/interceptor.go:139 +0x2b9
+google.golang.org/grpc.(*Server).processStreamingRPC(0xc000338200, {0x2815238, 0xc0044c4a50}, 0xc003d47680, 0xc0003e96b0, 0x3b84120, 0x0)
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/server.go:1702 +0x1253
+google.golang.org/grpc.(*Server).handleStream(0xc000338200, {0x2816060, 0xc001db69c0}, 0xc003d47680)
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/server.go:1819 +0xb54
+google.golang.org/grpc.(*Server).serveStreams.func2.1()
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/server.go:1035 +0x7f
+created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 727305
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/server.go:1046 +0x11d
+
+goroutine 726406 [select]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*Worker).run(0xc002117500, {0x2815270, 0xc000c73b30})
+	/workspace/internal/provider/processor/plan/worker.go:122 +0x6fe
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f6c0, {0x2815270, 0xc000c73b30}, {{0xc0050fc6d8, 0x453472?}, {0xc0033f09b0?, 0x0?}}, 0xc000dd0390?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 182
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 729444 [select, 8 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2.1()
+	/workspace/internal/provider/processor/requeue/processor.go:116 +0x111
+created by github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2 in goroutine 183
+	/workspace/internal/provider/processor/requeue/processor.go:112 +0x78d
+
+goroutine 726437 [select, 7 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).loop(0xc001ebb040, {0x2815270, 0xc000452370})
+	/workspace/internal/provider/processor/plan/timer.go:203 +0x177
+created by github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).Start in goroutine 726436
+	/workspace/internal/provider/processor/plan/timer.go:174 +0xd0
+
+goroutine 338 [select, 9 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*Worker).run(0xc0006e2700, {0x2815270, 0xc000427db0})
+	/workspace/internal/provider/processor/plan/worker.go:122 +0x6fe
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f6c0, {0x2815270, 0xc000427db0}, {{0xc0004389f0, 0x0?}, {0xc000438a08?, 0x0?}}, 0xc0016625a0?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 182
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 339 [select, 9 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).loop(0xc0016648c0, {0x2815270, 0xc000427e50})
+	/workspace/internal/provider/processor/plan/timer.go:203 +0x177
+created by github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).Start in goroutine 338
+	/workspace/internal/provider/processor/plan/timer.go:174 +0xd0
+
+goroutine 726418 [select]:
+github.com/ardikabs/hibernator/internal/provider/processor/status.(*UpdateProcessor[...].func3.1()
+	/workspace/pkg/keyedworker/handler.go:64 +0x191
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283efe0, {0x2815270, 0xc00453dae0}, {{0xc003570768, 0x453472?}, {0xc003570810?, 0xc002a67140?}}, 0xc001b2ecf0?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 726384
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 727503 [select, 7 minutes]:
+github.com/ardikabs/hibernator/internal/notification.(*Dispatcher).workerFactory-fm.(*Dispatcher).workerFactory.func1({0x2815270, 0xc001ea30e0})
+	/workspace/internal/notification/dispatcher.go:345 +0x2ce
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f560, {0x2815270, 0xc001ea30e0}, {{{0xc0046039e0, 0x11}, {0xc0046039c8, 0x12}}, {0xc0010385e0, 0x8}, {{0xc002450b40, ...}, ...}, ...}, ...)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c7
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 726827
+	/workspace/pkg/keyedworker/pool.go:312 +0x2c7
+
+goroutine 726403 [select, 9 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*Worker).run(0xc002116900, {0x2815270, 0xc000c738b0})
+	/workspace/internal/provider/processor/plan/worker.go:122 +0x6fe
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f6c0, {0x2815270, 0xc000c738b0}, {{0xc000439560, 0x453472?}, {0xc000439578?, 0xc0028dd9b0?}}, 0xc0018bbcb0?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 182
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 726504 [select, 9 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*Worker).run(0xc004911d00, {0x2815270, 0xc0043aa3c0})
+	/workspace/internal/provider/processor/plan/worker.go:122 +0x6fe
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f6c0, {0x2815270, 0xc0043aa3c0}, {{0xc000438c90, 0x92ad28?}, {0xc000438ca8?, 0x8607c5?}}, 0xc001890240?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 182
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 726428 [select, 9 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2.1()
+	/workspace/internal/provider/processor/requeue/processor.go:116 +0x111
+created by github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2 in goroutine 183
+	/workspace/internal/provider/processor/requeue/processor.go:112 +0x78d
+
+goroutine 726413 [select]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*Worker).run(0xc002117800, {0x2815270, 0xc00223a000})
+	/workspace/internal/provider/processor/plan/worker.go:122 +0x6fe
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f6c0, {0x2815270, 0xc00223a000}, {{0xc004788b40, 0x92ad28?}, {0xc00463db80?, 0x0?}}, 0xc000ce4750?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 182
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 734092 [sync.Cond.Wait]:
+sync.runtime_notifyListWait(0xc003b8ef48, 0x36)
+	/usr/local/go/src/runtime/sema.go:606 +0x159
+sync.(*Cond).Wait(0x9?)
+	/usr/local/go/src/sync/cond.go:71 +0x73
+golang.org/x/net/http2.(*pipe).Read(0xc003b8ef30, {0xc004058d80, 0x4, 0x4})
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/pipe.go:76 +0xdb
+golang.org/x/net/http2.transportResponseBody.Read({0x0?}, {0xc004058d80?, 0xc00288bcd0?, 0x41d305?})
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/transport.go:2560 +0x59
+io.ReadAtLeast({0x7f0b707dc000, 0xc003b8ef00}, {0xc004058d80, 0x4, 0x4}, 0x4)
+	/usr/local/go/src/io/io.go:335 +0x8e
+k8s.io/apimachinery/pkg/util/framer.(*lengthDelimitedFrameReader).Read(0xc00332c540, {0xc000dde000, 0x4000, 0x5000})
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/framer/framer.go:76 +0x7f
+k8s.io/apimachinery/pkg/runtime/serializer/streaming.(*decoder).Decode(0xc0052425a0, 0x0, {0x27fbf90, 0xc003500900})
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/runtime/serializer/streaming/streaming.go:77 +0xa3
+k8s.io/client-go/rest/watch.(*Decoder).Decode(0xc001641ac0)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/rest/watch/decoder.go:49 +0x4b
+k8s.io/apimachinery/pkg/watch.(*StreamWatcher).receive(0xc0052425f0)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/watch/streamwatcher.go:114 +0xf8
+created by k8s.io/apimachinery/pkg/watch.NewStreamWatcherWithLogger in goroutine 218
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/watch/streamwatcher.go:85 +0x149
+
+goroutine 732501 [select, 5 minutes]:
+golang.org/x/net/http2.(*clientStream).writeRequest(0xc004ac8300, 0xc004a94dc0, 0x0)
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/transport.go:1566 +0xc85
+golang.org/x/net/http2.(*clientStream).doRequest(0xc004ac8300, 0x2815238?, 0xc00012b7a0?)
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/transport.go:1427 +0x18
+created by golang.org/x/net/http2.(*ClientConn).roundTrip in goroutine 252
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/transport.go:1333 +0x485
+
+goroutine 726508 [select, 3 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).loop(0xc002ef9b80, {0x2815270, 0xc0043aa780})
+	/workspace/internal/provider/processor/plan/timer.go:203 +0x177
+created by github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).Start in goroutine 726507
+	/workspace/internal/provider/processor/plan/timer.go:174 +0xd0
+
+goroutine 726863 [select, 5 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/status.(*UpdateProcessor[...].func3.1()
+	/workspace/pkg/keyedworker/handler.go:64 +0x191
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283efe0, {0x2815270, 0xc001e7ba90}, {{0xc0049b9c08, 0x92ad28?}, {0xc002795620?, 0xc0027a1590?}}, 0xc002773b60?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 726861
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 727159 [select, 7 minutes]:
+github.com/ardikabs/hibernator/internal/notification.(*Dispatcher).workerFactory-fm.(*Dispatcher).workerFactory.func1({0x2815270, 0xc002c06cd0})
+	/workspace/internal/notification/dispatcher.go:345 +0x2ce
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f560, {0x2815270, 0xc002c06cd0}, {{{0xc003e2a8b8, 0x11}, {0xc003e2a8a0, 0x14}}, {0xc0025a2b40, 0x8}, {{0xc002450b40, ...}, ...}, ...}, ...)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c7
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 726500
+	/workspace/pkg/keyedworker/pool.go:312 +0x2c7
+
+goroutine 726856 [select, 3 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).loop(0xc0031ef720, {0x2815270, 0xc001e7afa0})
+	/workspace/internal/provider/processor/plan/timer.go:203 +0x177
+created by github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).Start in goroutine 726855
+	/workspace/internal/provider/processor/plan/timer.go:174 +0xd0
+
+goroutine 733018 [select, 3 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2.1()
+	/workspace/internal/provider/processor/requeue/processor.go:116 +0x111
+created by github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2 in goroutine 183
+	/workspace/internal/provider/processor/requeue/processor.go:112 +0x78d
+
+goroutine 734313 [select, 1 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2.1()
+	/workspace/internal/provider/processor/requeue/processor.go:116 +0x111
+created by github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2 in goroutine 183
+	/workspace/internal/provider/processor/requeue/processor.go:112 +0x78d
+
+goroutine 733220 [select, 2 minutes]:
+golang.org/x/net/http2.(*clientStream).writeRequest(0xc0009db380, 0xc001b99900, 0x0)
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/transport.go:1566 +0xc85
+golang.org/x/net/http2.(*clientStream).doRequest(0xc0009db380, 0x0?, 0xc005398a30?)
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/transport.go:1427 +0x18
+created by golang.org/x/net/http2.(*ClientConn).roundTrip in goroutine 21603
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/transport.go:1333 +0x485
+
+goroutine 304 [select, 8 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*Worker).run(0xc000313c00, {0x2815270, 0xc001e7a050})
+	/workspace/internal/provider/processor/plan/worker.go:122 +0x6fe
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f6c0, {0x2815270, 0xc001e7a050}, {{0xc000438240, 0x0?}, {0xc000438258?, 0x0?}}, 0xc001e3bdd0?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 182
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 369 [select, 8 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).loop(0xc001e675e0, {0x2815270, 0xc001e7a0f0})
+	/workspace/internal/provider/processor/plan/timer.go:203 +0x177
+created by github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).Start in goroutine 304
+	/workspace/internal/provider/processor/plan/timer.go:174 +0xd0
+
+goroutine 726513 [select, 9 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*Worker).run(0xc001d04300, {0x2815270, 0xc00425eaf0})
+	/workspace/internal/provider/processor/plan/worker.go:122 +0x6fe
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f6c0, {0x2815270, 0xc00425eaf0}, {{0xc000439938, 0x92ad28?}, {0xc00043aa30?, 0xc0046150e0?}}, 0xc001c28900?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 182
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 726843 [select, 8 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*Worker).run(0xc0034afc00, {0x2815270, 0xc0031f0ff0})
+	/workspace/internal/provider/processor/plan/worker.go:122 +0x6fe
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f6c0, {0x2815270, 0xc0031f0ff0}, {{0xc0037dfb90, 0x92ad28?}, {0xc0037dfc08?, 0xc0029a4358?}}, 0xc00123f2f0?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 182
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 727813 [select]:
+github.com/ardikabs/hibernator/internal/provider/processor/status.(*UpdateProcessor[...].func3.1()
+	/workspace/pkg/keyedworker/handler.go:64 +0x191
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f2a0, {0x2815270, 0xc001fa2d70}, {{0xc002450b40, 0x92ad28?}, {0xc002450ae0?, 0xc002b7e0e8?}}, 0xc001c69860?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 727029
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 607985 [select, 262 minutes]:
+k8s.io/client-go/tools/cache.(*Reflector).startResync(0xc000134b40, {0x2815270, 0xc003a19cc0}, 0xc0047917a0)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:450 +0x12d
+k8s.io/client-go/tools/cache.(*Reflector).watchWithResync.func2()
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:480 +0x25
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:72 +0x4c
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 228
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:70 +0x73
+
+goroutine 726425 [select, 1 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/status.(*UpdateProcessor[...].func3.1()
+	/workspace/pkg/keyedworker/handler.go:64 +0x191
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283efe0, {0x2815270, 0xc0022ad8b0}, {{0xc003c26ab0, 0x453472?}, {0xc003c26b28?, 0xc00199d1d0?}}, 0xc001e7f440?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 726423
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 726901 [select, 8 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/status.(*UpdateProcessor[...].func3.1()
+	/workspace/pkg/keyedworker/handler.go:64 +0x191
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283efe0, {0x2815270, 0xc00023c5a0}, {{0xc0032aecd8, 0x92ad28?}, {0xc0032af080?, 0x8607c5?}}, 0xc0014a1a70?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 726899
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 731454 [sync.Cond.Wait]:
+sync.runtime_notifyListWait(0xc003868048, 0x29)
+	/usr/local/go/src/runtime/sema.go:606 +0x159
+sync.(*Cond).Wait(0x27ed040?)
+	/usr/local/go/src/sync/cond.go:71 +0x73
+golang.org/x/net/http2.(*pipe).Read(0xc003868030, {0xc001e98001, 0x7dff, 0x7dff})
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/pipe.go:76 +0xdb
+golang.org/x/net/http2.transportResponseBody.Read({0x0?}, {0xc001e98001?, 0x41c8d4?, 0x0?})
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/transport.go:2560 +0x59
+encoding/json.(*Decoder).refill(0xc003573540)
+	/usr/local/go/src/encoding/json/stream.go:167 +0x188
+encoding/json.(*Decoder).readValue(0xc003573540)
+	/usr/local/go/src/encoding/json/stream.go:142 +0x85
+encoding/json.(*Decoder).Decode(0xc003573540, {0x20b2220, 0xc0022c33b0})
+	/usr/local/go/src/encoding/json/stream.go:65 +0x75
+k8s.io/apimachinery/pkg/util/framer.(*jsonFrameReader).Read(0xc00333b4d0, {0xc001f80000, 0x8000, 0xa000})
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/framer/framer.go:151 +0x15c
+k8s.io/apimachinery/pkg/runtime/serializer/streaming.(*decoder).Decode(0xc00045b950, 0x0, {0x27fbf90, 0xc003500280})
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/runtime/serializer/streaming/streaming.go:77 +0xa3
+k8s.io/client-go/rest/watch.(*Decoder).Decode(0xc003b3abe0)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/rest/watch/decoder.go:49 +0x4b
+k8s.io/apimachinery/pkg/watch.(*StreamWatcher).receive(0xc00045b9a0)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/watch/streamwatcher.go:114 +0xf8
+created by k8s.io/apimachinery/pkg/watch.NewStreamWatcherWithLogger in goroutine 228
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/watch/streamwatcher.go:85 +0x149
+
+goroutine 607968 [select, 1348 minutes]:
+context.(*cancelCtx).propagateCancel.func2()
+	/usr/local/go/src/context/context.go:523 +0x98
+created by context.(*cancelCtx).propagateCancel in goroutine 228
+	/usr/local/go/src/context/context.go:522 +0x409
+
+goroutine 726586 [select, 8 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2.1()
+	/workspace/internal/provider/processor/requeue/processor.go:116 +0x111
+created by github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2 in goroutine 183
+	/workspace/internal/provider/processor/requeue/processor.go:112 +0x78d
+
+goroutine 726399 [select, 1 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/status.(*UpdateProcessor[...].func3.1()
+	/workspace/pkg/keyedworker/handler.go:64 +0x191
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283efe0, {0x2815270, 0xc0042a9ef0}, {{0xc00359ed50, 0x453472?}, {0xc00359edc8?, 0xc00411b350?}}, 0xc002220d80?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 726397
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 727456 [select, 2 minutes]:
+github.com/ardikabs/hibernator/internal/notification.(*Dispatcher).workerFactory-fm.(*Dispatcher).workerFactory.func1({0x2815270, 0xc0052422d0})
+	/workspace/internal/notification/dispatcher.go:345 +0x2ce
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f560, {0x2815270, 0xc0052422d0}, {{{0xc0030ada58, 0x11}, {0xc002ac5570, 0xf}}, {0xc002ac5668, 0x8}, {{0xc002450b40, ...}, ...}, ...}, ...)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c7
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 726408
+	/workspace/pkg/keyedworker/pool.go:312 +0x2c7
+
+goroutine 726500 [select, 8 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/status.(*UpdateProcessor[...].func3.1()
+	/workspace/pkg/keyedworker/handler.go:64 +0x191
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283efe0, {0x2815270, 0xc004ded220}, {{0xc0036836b0, 0x453472?}, {0xc003683728?, 0x0?}}, 0xc0023b3350?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 726498
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 734485 [select]:
+github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2.1()
+	/workspace/internal/provider/processor/requeue/processor.go:116 +0x111
+created by github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2 in goroutine 183
+	/workspace/internal/provider/processor/requeue/processor.go:112 +0x78d
+
+goroutine 726827 [runnable]:
+github.com/ardikabs/hibernator/internal/provider/processor/status.(*UpdateProcessor[...].func3.1()
+	/workspace/pkg/keyedworker/handler.go:64 +0x191
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283efe0, {0x2815270, 0xc004c93040}, {{0xc0047640f0, 0x222c7d7b3a226573?}, {0xc004764138?, 0x6472612e726f7461?}}, 0xc0031ffad0?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 726825
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 726453 [select]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).loop(0xc0024ce500, {0x2815270, 0xc0043d55e0})
+	/workspace/internal/provider/processor/plan/timer.go:203 +0x177
+created by github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).Start in goroutine 726452
+	/workspace/internal/provider/processor/plan/timer.go:174 +0xd0
+
+goroutine 727294 [select, 3 minutes]:
+github.com/ardikabs/hibernator/internal/notification.(*Dispatcher).workerFactory-fm.(*Dispatcher).workerFactory.func1({0x2815270, 0xc0040312c0})
+	/workspace/internal/notification/dispatcher.go:345 +0x2ce
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f560, {0x2815270, 0xc0040312c0}, {{{0xc0027e4c90, 0x11}, {0xc0018a7ff0, 0x10}}, {0xc0037dc2c0, 0x8}, {{0xc002450b40, ...}, ...}, ...}, ...)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c7
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 726857
+	/workspace/pkg/keyedworker/pool.go:312 +0x2c7
+
+goroutine 726837 [select, 8 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*Worker).run(0xc0034af800, {0x2815270, 0xc0031f04b0})
+	/workspace/internal/provider/processor/plan/worker.go:122 +0x6fe
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f6c0, {0x2815270, 0xc0031f04b0}, {{0xc003cf6870, 0x92ad28?}, {0xc003cf6948?, 0xc00167e310?}}, 0xc0018f0ba0?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 182
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 726514 [select, 9 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).loop(0xc002d04be0, {0x2815270, 0xc00425eb90})
+	/workspace/internal/provider/processor/plan/timer.go:203 +0x177
+created by github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).Start in goroutine 726513
+	/workspace/internal/provider/processor/plan/timer.go:174 +0xd0
+
+goroutine 734145 [select, 1 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2.1()
+	/workspace/internal/provider/processor/requeue/processor.go:116 +0x111
+created by github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2 in goroutine 183
+	/workspace/internal/provider/processor/requeue/processor.go:112 +0x78d
+
+goroutine 727511 [select]:
+github.com/ardikabs/hibernator/internal/notification.(*Dispatcher).workerFactory-fm.(*Dispatcher).workerFactory.func1({0x2815270, 0xc005243540})
+	/workspace/internal/notification/dispatcher.go:345 +0x2ce
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f560, {0x2815270, 0xc005243540}, {{{0xc0008f1da0, 0x11}, {0xc0008f1d58, 0x11}}, {0xc004b07cc0, 0x8}, {{0xc002450b40, ...}, ...}, ...}, ...)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c7
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 726432
+	/workspace/pkg/keyedworker/pool.go:312 +0x2c7
+
+goroutine 696752 [IO wait]:
+internal/poll.runtime_pollWait(0x7f0b70514600, 0x72)
+	/usr/local/go/src/runtime/netpoll.go:351 +0x85
+internal/poll.(*pollDesc).wait(0xc004d0b180?, 0xc000d66000?, 0x0)
+	/usr/local/go/src/internal/poll/fd_poll_runtime.go:84 +0x27
+internal/poll.(*pollDesc).waitRead(...)
+	/usr/local/go/src/internal/poll/fd_poll_runtime.go:89
+internal/poll.(*FD).Read(0xc004d0b180, {0xc000d66000, 0xa000, 0xa000})
+	/usr/local/go/src/internal/poll/fd_unix.go:165 +0x279
+net.(*netFD).Read(0xc004d0b180, {0xc000d66000?, 0xc000d66000?, 0x5?})
+	/usr/local/go/src/net/fd_posix.go:68 +0x25
+net.(*conn).Read(0xc0050902d0, {0xc000d66000?, 0x7f0b704723e8?, 0x7f0bb74855c0?})
+	/usr/local/go/src/net/net.go:196 +0x45
+crypto/tls.(*atLeastReader).Read(0xc004536588, {0xc000d66000?, 0x9ffb?, 0x1a?})
+	/usr/local/go/src/crypto/tls/conn.go:819 +0x3b
+bytes.(*Buffer).ReadFrom(0xc002c08d28, {0x27ef560, 0xc004536588})
+	/usr/local/go/src/bytes/buffer.go:217 +0x98
+crypto/tls.(*Conn).readFromUntil(0xc002c08a88, {0x27ef680, 0xc0050902d0}, 0xc00288e9d0?)
+	/usr/local/go/src/crypto/tls/conn.go:841 +0xde
+crypto/tls.(*Conn).readRecordOrCCS(0xc002c08a88, 0x0)
+	/usr/local/go/src/crypto/tls/conn.go:630 +0x3db
+crypto/tls.(*Conn).readRecord(...)
+	/usr/local/go/src/crypto/tls/conn.go:592
+crypto/tls.(*Conn).Read(0xc002c08a88, {0xc00128e000, 0x1000, 0xc00288ecb0?})
+	/usr/local/go/src/crypto/tls/conn.go:1397 +0x145
+bufio.(*Reader).Read(0xc001be31a0, {0xc004af84a4, 0x9, 0x7aa?})
+	/usr/local/go/src/bufio/bufio.go:245 +0x197
+io.ReadAtLeast({0x27edea0, 0xc001be31a0}, {0xc004af84a4, 0x9, 0x9}, 0x9)
+	/usr/local/go/src/io/io.go:335 +0x8e
+io.ReadFull(...)
+	/usr/local/go/src/io/io.go:354
+golang.org/x/net/http2.readFrameHeader({0xc004af84a4, 0x9, 0x675b?}, {0x27edea0?, 0xc001be31a0?})
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/frame.go:242 +0x65
+golang.org/x/net/http2.(*Framer).ReadFrameHeader(0xc004af8460)
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/frame.go:505 +0x6b
+golang.org/x/net/http2.(*Framer).ReadFrame(0xc004af8460)
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/frame.go:564 +0x18
+golang.org/x/net/http2.(*clientConnReadLoop).run(0xc00288efa8)
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/transport.go:2258 +0xca
+golang.org/x/net/http2.(*ClientConn).readLoop(0xc002c7afc0)
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/transport.go:2127 +0x52
+created by golang.org/x/net/http2.(*Transport).newClientConn in goroutine 696751
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/transport.go:880 +0xda5
+
+goroutine 727258 [select, 7 minutes]:
+github.com/ardikabs/hibernator/internal/notification.(*Dispatcher).workerFactory-fm.(*Dispatcher).workerFactory.func1({0x2815270, 0xc004030be0})
+	/workspace/internal/notification/dispatcher.go:345 +0x2ce
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f560, {0x2815270, 0xc004030be0}, {{{0xc003496c78, 0x11}, {0xc003496c60, 0x11}}, {0xc0004be950, 0x8}, {{0xc002450b40, ...}, ...}, ...}, ...)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c7
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 726845
+	/workspace/pkg/keyedworker/pool.go:312 +0x2c7
+
+goroutine 734673 [select]:
+github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2.1()
+	/workspace/internal/provider/processor/requeue/processor.go:116 +0x111
+created by github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2 in goroutine 183
+	/workspace/internal/provider/processor/requeue/processor.go:112 +0x78d
+
+goroutine 726397 [select, 1 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*Worker).run(0xc002116400, {0x2815270, 0xc0042a9e00})
+	/workspace/internal/provider/processor/plan/worker.go:122 +0x6fe
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f6c0, {0x2815270, 0xc0042a9e00}, {{0xc00359ed50, 0x453472?}, {0xc00359edc8?, 0xc003da7e90?}}, 0xc0018910b0?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 182
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 727409 [IO wait]:
+internal/poll.runtime_pollWait(0x7f0b70514e00, 0x72)
+	/usr/local/go/src/runtime/netpoll.go:351 +0x85
+internal/poll.(*pollDesc).wait(0xc005131f00?, 0xc0018a8000?, 0x0)
+	/usr/local/go/src/internal/poll/fd_poll_runtime.go:84 +0x27
+internal/poll.(*pollDesc).waitRead(...)
+	/usr/local/go/src/internal/poll/fd_poll_runtime.go:89
+internal/poll.(*FD).Read(0xc005131f00, {0xc0018a8000, 0x8000, 0x8000})
+	/usr/local/go/src/internal/poll/fd_unix.go:165 +0x279
+net.(*netFD).Read(0xc005131f00, {0xc0018a8000?, 0xc0044ccc00?, 0x414134?})
+	/usr/local/go/src/net/fd_posix.go:68 +0x25
+net.(*conn).Read(0xc00044eac8, {0xc0018a8000?, 0x47e885?, 0xc0049c75d8?})
+	/usr/local/go/src/net/net.go:196 +0x45
+bufio.(*Reader).Read(0xc002c2c360, {0xc004af9464, 0x9, 0x4b23da?})
+	/usr/local/go/src/bufio/bufio.go:245 +0x197
+io.ReadAtLeast({0x27edea0, 0xc002c2c360}, {0xc004af9464, 0x9, 0x9}, 0x9)
+	/usr/local/go/src/io/io.go:335 +0x8e
+io.ReadFull(...)
+	/usr/local/go/src/io/io.go:354
+golang.org/x/net/http2.readFrameHeader({0xc004af9464, 0x9, 0x1d0181c?}, {0x27edea0?, 0xc002c2c360?})
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/frame.go:242 +0x65
+golang.org/x/net/http2.(*Framer).ReadFrameHeader(0xc004af9420)
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/frame.go:505 +0x6b
+golang.org/x/net/http2.(*Framer).ReadFrame(0xc004af9420)
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/frame.go:564 +0x18
+google.golang.org/grpc/internal/transport.(*http2Server).HandleStreams(0xc003cc3040, {0x2815238, 0xc0017a4540}, 0xc0017a4570)
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/internal/transport/http2_server.go:657 +0x105
+google.golang.org/grpc.(*Server).serveStreams(0xc000338200, {0x2814cd8?, 0x3bd39e0?}, {0x2816060, 0xc003cc3040}, {0x281e918?, 0xc00044eac8?})
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/server.go:1029 +0x3af
+google.golang.org/grpc.(*Server).handleRawConn.func1()
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/server.go:964 +0x56
+created by google.golang.org/grpc.(*Server).handleRawConn in goroutine 727390
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/server.go:963 +0x1cb
+
+goroutine 726862 [select, 5 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).loop(0xc00173cfa0, {0x2815270, 0xc001e7ba40})
+	/workspace/internal/provider/processor/plan/timer.go:203 +0x177
+created by github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).Start in goroutine 726861
+	/workspace/internal/provider/processor/plan/timer.go:174 +0xd0
+
+goroutine 733766 [select, 2 minutes]:
+golang.org/x/net/http2.(*clientStream).writeRequest(0xc004505b00, 0xc004b6c140, 0x0)
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/transport.go:1566 +0xc85
+golang.org/x/net/http2.(*clientStream).doRequest(0xc004505b00, 0xc000670fb0?, 0xc000670fa0?)
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/transport.go:1427 +0x18
+created by golang.org/x/net/http2.(*ClientConn).roundTrip in goroutine 101
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/transport.go:1333 +0x485
+
+goroutine 731453 [select, 7 minutes]:
+golang.org/x/net/http2.(*clientStream).writeRequest(0xc003868000, 0xc0035732c0, 0x0)
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/transport.go:1566 +0xc85
+golang.org/x/net/http2.(*clientStream).doRequest(0xc003868000, 0x0?, 0xc001483810?)
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/transport.go:1427 +0x18
+created by golang.org/x/net/http2.(*ClientConn).roundTrip in goroutine 228
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/transport.go:1333 +0x485
+
+goroutine 732525 [select, 5 minutes]:
+golang.org/x/net/http2.(*clientStream).writeRequest(0xc004d35800, 0xc004ed0dc0, 0x0)
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/transport.go:1566 +0xc85
+golang.org/x/net/http2.(*clientStream).doRequest(0xc004d35800, 0xc0004bbfb0?, 0xc0004bbfa0?)
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/transport.go:1427 +0x18
+created by golang.org/x/net/http2.(*ClientConn).roundTrip in goroutine 235
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/transport.go:1333 +0x485
+
+goroutine 728905 [select, 8 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2.1()
+	/workspace/internal/provider/processor/requeue/processor.go:116 +0x111
+created by github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2 in goroutine 183
+	/workspace/internal/provider/processor/requeue/processor.go:112 +0x78d
+
+goroutine 726424 [select, 1 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).loop(0xc0014e7b80, {0x2815270, 0xc0022ad860})
+	/workspace/internal/provider/processor/plan/timer.go:203 +0x177
+created by github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).Start in goroutine 726423
+	/workspace/internal/provider/processor/plan/timer.go:174 +0xd0
+
+goroutine 726821 [select, 8 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2.1()
+	/workspace/internal/provider/processor/requeue/processor.go:116 +0x111
+created by github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2 in goroutine 183
+	/workspace/internal/provider/processor/requeue/processor.go:112 +0x78d
+
+goroutine 733767 [sync.Cond.Wait]:
+sync.runtime_notifyListWait(0xc004505b48, 0x1)
+	/usr/local/go/src/runtime/sema.go:606 +0x159
+sync.(*Cond).Wait(0x27ed040?)
+	/usr/local/go/src/sync/cond.go:71 +0x73
+golang.org/x/net/http2.(*pipe).Read(0xc004505b30, {0xc0039eb201, 0x5ff, 0x5ff})
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/pipe.go:76 +0xdb
+golang.org/x/net/http2.transportResponseBody.Read({0x0?}, {0xc0039eb201?, 0x41c8d4?, 0x0?})
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/transport.go:2560 +0x59
+encoding/json.(*Decoder).refill(0xc004b6c3c0)
+	/usr/local/go/src/encoding/json/stream.go:167 +0x188
+encoding/json.(*Decoder).readValue(0xc004b6c3c0)
+	/usr/local/go/src/encoding/json/stream.go:142 +0x85
+encoding/json.(*Decoder).Decode(0xc004b6c3c0, {0x20b2220, 0xc003285320})
+	/usr/local/go/src/encoding/json/stream.go:65 +0x75
+k8s.io/apimachinery/pkg/util/framer.(*jsonFrameReader).Read(0xc0032aacc0, {0xc0047e3800, 0x400, 0x400})
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/framer/framer.go:151 +0x15c
+k8s.io/apimachinery/pkg/runtime/serializer/streaming.(*decoder).Decode(0xc0030bb590, 0x0, {0x27fbf90, 0xc00407b480})
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/runtime/serializer/streaming/streaming.go:77 +0xa3
+k8s.io/client-go/rest/watch.(*Decoder).Decode(0xc004a4a1c0)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/rest/watch/decoder.go:49 +0x4b
+k8s.io/apimachinery/pkg/watch.(*StreamWatcher).receive(0xc0030bb5e0)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/watch/streamwatcher.go:114 +0xf8
+created by k8s.io/apimachinery/pkg/watch.NewStreamWatcherWithLogger in goroutine 101
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/watch/streamwatcher.go:85 +0x149
+
+goroutine 729249 [select, 8 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2.1()
+	/workspace/internal/provider/processor/requeue/processor.go:116 +0x111
+created by github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2 in goroutine 183
+	/workspace/internal/provider/processor/requeue/processor.go:112 +0x78d
+
+goroutine 726849 [select, 7 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*Worker).run(0xc002544a00, {0x2815270, 0xc001e7a4b0})
+	/workspace/internal/provider/processor/plan/worker.go:122 +0x6fe
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f6c0, {0x2815270, 0xc001e7a4b0}, {{0xc003e1d128, 0x92ad28?}, {0xc0022571f0?, 0xc002738d20?}}, 0xc000539350?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 182
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 727081 [select, 1 minutes]:
+github.com/ardikabs/hibernator/internal/notification.(*Dispatcher).workerFactory-fm.(*Dispatcher).workerFactory.func1({0x2815270, 0xc00274fdb0})
+	/workspace/internal/notification/dispatcher.go:345 +0x2ce
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f560, {0x2815270, 0xc00274fdb0}, {{{0xc00087a348, 0x11}, {0xc00087a318, 0x15}}, {0xc004059e70, 0x8}, {{0xc002450b40, ...}, ...}, ...}, ...)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c7
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 726399
+	/workspace/pkg/keyedworker/pool.go:312 +0x2c7
+
+goroutine 726831 [select]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*Worker).run(0xc0034af400, {0x2815270, 0xc004c93950})
+	/workspace/internal/provider/processor/plan/worker.go:122 +0x6fe
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f6c0, {0x2815270, 0xc004c93950}, {{0xc004b947c8, 0x92ad28?}, {0xc004b94840?, 0xc000376be0?}}, 0xc0011cb890?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 182
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 726900 [select]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).loop(0xc001b25180, {0x2815270, 0xc00023c550})
+	/workspace/internal/provider/processor/plan/timer.go:203 +0x177
+created by github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).Start in goroutine 726899
+	/workspace/internal/provider/processor/plan/timer.go:174 +0xd0
+
+goroutine 726503 [select, 9 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2.1()
+	/workspace/internal/provider/processor/requeue/processor.go:116 +0x111
+created by github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2 in goroutine 183
+	/workspace/internal/provider/processor/requeue/processor.go:112 +0x78d
+
+goroutine 608004 [select, 176 minutes]:
+k8s.io/client-go/tools/cache.(*Reflector).startResync(0xc0001344b0, {0x2815270, 0xc0033aa690}, 0xc003604310)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:450 +0x12d
+k8s.io/client-go/tools/cache.(*Reflector).watchWithResync.func2()
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:480 +0x25
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:72 +0x4c
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 101
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:70 +0x73
+
+goroutine 726398 [select, 1 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).loop(0xc004013b80, {0x2815270, 0xc0042a9ea0})
+	/workspace/internal/provider/processor/plan/timer.go:203 +0x177
+created by github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).Start in goroutine 726397
+	/workspace/internal/provider/processor/plan/timer.go:174 +0xd0
+
+goroutine 726417 [select]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).loop(0xc0036a75e0, {0x2815270, 0xc00453da90})
+	/workspace/internal/provider/processor/plan/timer.go:203 +0x177
+created by github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).Start in goroutine 726384
+	/workspace/internal/provider/processor/plan/timer.go:174 +0xd0
+
+goroutine 21399 [select]:
+k8s.io/client-go/tools/record.(*eventBroadcasterImpl).StartEventWatcher.func1()
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/record/event.go:407 +0xfe
+created by k8s.io/client-go/tools/record.(*eventBroadcasterImpl).StartEventWatcher in goroutine 21373
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/record/event.go:404 +0xb2
+
+goroutine 726588 [select]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*Worker).run(0xc000c77d00, {0x2815270, 0xc004a732c0})
+	/workspace/internal/provider/processor/plan/worker.go:122 +0x6fe
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f6c0, {0x2815270, 0xc004a732c0}, {{0xc003ad8d20, 0x92ad28?}, {0xc003ad8d98?, 0xc0037fbb08?}}, 0xc001663350?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 182
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 727244 [select, 7 minutes]:
+github.com/ardikabs/hibernator/internal/notification.(*Dispatcher).workerFactory-fm.(*Dispatcher).workerFactory.func1({0x2815270, 0xc0037a8190})
+	/workspace/internal/notification/dispatcher.go:345 +0x2ce
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f560, {0x2815270, 0xc0037a8190}, {{{0xc00482e390, 0x11}, {0xc00482e360, 0x16}}, {0xc0033f6540, 0x8}, {{0xc002450b40, ...}, ...}, ...}, ...)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c7
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 726590
+	/workspace/pkg/keyedworker/pool.go:312 +0x2c7
+
+goroutine 726830 [select, 8 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2.1()
+	/workspace/internal/provider/processor/requeue/processor.go:116 +0x111
+created by github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2 in goroutine 183
+	/workspace/internal/provider/processor/requeue/processor.go:112 +0x78d
+
+goroutine 726423 [select, 1 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*Worker).run(0xc000d27c00, {0x2815270, 0xc0022ad7c0})
+	/workspace/internal/provider/processor/plan/worker.go:122 +0x6fe
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f6c0, {0x2815270, 0xc0022ad7c0}, {{0xc003c26ab0, 0x453472?}, {0xc003c26b28?, 0xc00487f500?}}, 0xc000cbd890?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 182
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 726861 [select, 5 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*Worker).run(0xc002545c00, {0x2815270, 0xc001e7b9a0})
+	/workspace/internal/provider/processor/plan/worker.go:122 +0x6fe
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f6c0, {0x2815270, 0xc001e7b9a0}, {{0xc0049b9c08, 0x92ad28?}, {0xc002795620?, 0xc0027a1590?}}, 0xc0018ba000?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 182
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 726647 [select, 8 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2.1()
+	/workspace/internal/provider/processor/requeue/processor.go:116 +0x111
+created by github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2 in goroutine 183
+	/workspace/internal/provider/processor/requeue/processor.go:112 +0x78d
+
+goroutine 734091 [select, 1 minutes]:
+golang.org/x/net/http2.(*clientStream).writeRequest(0xc003b8ef00, 0xc001b82f00, 0x0)
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/transport.go:1566 +0xc85
+golang.org/x/net/http2.(*clientStream).doRequest(0xc003b8ef00, 0x93d8a5?, 0xc0003f5450?)
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/transport.go:1427 +0x18
+created by golang.org/x/net/http2.(*ClientConn).roundTrip in goroutine 218
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/transport.go:1333 +0x485
+
+goroutine 726822 [select, 8 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*Worker).run(0xc0034ae100, {0x2815270, 0xc004c92640})
+	/workspace/internal/provider/processor/plan/worker.go:122 +0x6fe
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f6c0, {0x2815270, 0xc004c92640}, {{0xc000695f20, 0x453472?}, {0xc000695f38?, 0xc00122bea0?}}, 0xc000e7c1e0?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 182
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 726590 [select, 8 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/status.(*UpdateProcessor[...].func3.1()
+	/workspace/pkg/keyedworker/handler.go:64 +0x191
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283efe0, {0x2815270, 0xc004a733b0}, {{0xc003ad8d20, 0x92ad28?}, {0xc003ad8d98?, 0xc0037fbb08?}}, 0xc00087ec90?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 726588
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 21397 [chan receive]:
+k8s.io/apimachinery/pkg/watch.(*Broadcaster).loop(0xc00052afa0)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/watch/mux.go:268 +0x66
+created by k8s.io/apimachinery/pkg/watch.NewLongQueueBroadcaster in goroutine 21373
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/watch/mux.go:93 +0x116
+
+goroutine 608009 [select, 190 minutes]:
+k8s.io/client-go/tools/cache.(*Reflector).startResync(0xc000134d20, {0x2815270, 0xc0033aa960}, 0xc003604540)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:450 +0x12d
+k8s.io/client-go/tools/cache.(*Reflector).watchWithResync.func2()
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:480 +0x25
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:72 +0x4c
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 235
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:70 +0x73
+
+goroutine 726509 [select, 3 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/status.(*UpdateProcessor[...].func3.1()
+	/workspace/pkg/keyedworker/handler.go:64 +0x191
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283efe0, {0x2815270, 0xc0043aa7d0}, {{0xc0038bed08, 0x92ad28?}, {0xc0038bed80?, 0x93d8a5?}}, 0xc000c8c810?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 726507
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 727304 [select, 8 minutes]:
+google.golang.org/grpc/internal/transport.(*http2Server).keepalive(0xc001db69c0)
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/internal/transport/http2_server.go:1197 +0x1ea
+created by google.golang.org/grpc/internal/transport.NewServerTransport in goroutine 727302
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/internal/transport/http2_server.go:357 +0x18dd
+
+goroutine 734650 [runnable]:
+sigs.k8s.io/controller-runtime/pkg/client.(*mergeFromPatch).Data(0xc0035fe000, {0x283cd18, 0xc0031c1608})
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/client/patch.go:100 +0x33b
+sigs.k8s.io/controller-runtime/pkg/client.(*typedClient).Patch(0xc00033c750, {0x2815270, 0xc004c92f50}, {0x283cd18, 0xc0031c1608}, {0x27fc148, 0xc0035fe000}, {0x0, 0x0, 0x0})
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/client/typed_client.go:117 +0xb3
+sigs.k8s.io/controller-runtime/pkg/client.(*client).Patch(0xc00033c750, {0x2815270, 0xc004c92f50}, {0x283cd18, 0xc0031c1608}, {0x27fc148, 0xc0035fe000}, {0x0, 0x0, 0x0})
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/client/client.go:329 +0x2ca
+github.com/ardikabs/hibernator/internal/provider/processor/plan/state.(*state).markJobAsStale(0xc000356f00, {0x2815270, 0xc004c92f50}, {{0x281a520?, 0xc004119440?}, 0xc002b896f8?}, 0xc0031c1608)
+	/workspace/internal/provider/processor/plan/state/state_execution.go:462 +0x229
+created by github.com/ardikabs/hibernator/internal/provider/processor/plan/state.(*state).updateExecutionStatuses in goroutine 726825
+	/workspace/internal/provider/processor/plan/state/state_execution.go:366 +0x1ad9
+
+goroutine 726823 [select, 8 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).loop(0xc00301cbe0, {0x2815270, 0xc004c926e0})
+	/workspace/internal/provider/processor/plan/timer.go:203 +0x177
+created by github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).Start in goroutine 726822
+	/workspace/internal/provider/processor/plan/timer.go:174 +0xd0
+
+goroutine 726384 [select]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*Worker).run(0xc000d27400, {0x2815270, 0xc00453d9f0})
+	/workspace/internal/provider/processor/plan/worker.go:122 +0x6fe
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f6c0, {0x2815270, 0xc00453d9f0}, {{0xc003570768, 0x453472?}, {0xc003570810?, 0xc0046150e0?}}, 0xc0009997a0?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 182
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 726845 [select, 8 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/status.(*UpdateProcessor[...].func3.1()
+	/workspace/pkg/keyedworker/handler.go:64 +0x191
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283efe0, {0x2815270, 0xc0031f10e0}, {{0xc0037dfb90, 0x92ad28?}, {0xc0037dfc08?, 0xc0029a4358?}}, 0xc0044b25d0?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 726843
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 726517 [select, 8 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*Worker).run(0xc001d04600, {0x2815270, 0xc00425fcc0})
+	/workspace/internal/provider/processor/plan/worker.go:122 +0x6fe
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f6c0, {0x2815270, 0xc00425fcc0}, {{0xc003fe4e40, 0x86c0e8?}, {0xc003fe4ed0?, 0x2815238?}}, 0xc000cbc7e0?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 182
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 727029 [select, 1 minutes]:
+github.com/ardikabs/hibernator/internal/notification.(*Dispatcher).workerFactory-fm.(*Dispatcher).workerFactory.func1({0x2815270, 0xc0026d98b0})
+	/workspace/internal/notification/dispatcher.go:345 +0x2ce
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f560, {0x2815270, 0xc0026d98b0}, {{{0xc0038c04f8, 0x11}, {0xc0038c04e0, 0x15}}, {0xc003f77f70, 0x8}, {{0xc002450b40, ...}, ...}, ...}, ...)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c7
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 726425
+	/workspace/pkg/keyedworker/pool.go:312 +0x2c7
+
+goroutine 726838 [select, 8 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).loop(0xc003e7bcc0, {0x2815270, 0xc0031f0550})
+	/workspace/internal/provider/processor/plan/timer.go:203 +0x177
+created by github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).Start in goroutine 726837
+	/workspace/internal/provider/processor/plan/timer.go:174 +0xd0
+
+goroutine 733221 [sync.Cond.Wait]:
+sync.runtime_notifyListWait(0xc0009db3c8, 0xad)
+	/usr/local/go/src/runtime/sema.go:606 +0x159
+sync.(*Cond).Wait(0x3?)
+	/usr/local/go/src/sync/cond.go:71 +0x73
+golang.org/x/net/http2.(*pipe).Read(0xc0009db3b0, {0xc004bcb9fc, 0x4, 0x4})
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/pipe.go:76 +0xdb
+golang.org/x/net/http2.transportResponseBody.Read({0x0?}, {0xc004bcb9fc?, 0xc000709cd0?, 0x41d305?})
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/transport.go:2560 +0x59
+io.ReadAtLeast({0x7f0b707dc000, 0xc0009db380}, {0xc004bcb9fc, 0x4, 0x4}, 0x4)
+	/usr/local/go/src/io/io.go:335 +0x8e
+k8s.io/apimachinery/pkg/util/framer.(*lengthDelimitedFrameReader).Read(0xc00172f170, {0xc004766000, 0x10000, 0x14000})
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/framer/framer.go:76 +0x7f
+k8s.io/apimachinery/pkg/runtime/serializer/streaming.(*decoder).Decode(0xc002b50b90, 0x0, {0x27fbf90, 0xc0042f8bc0})
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/runtime/serializer/streaming/streaming.go:77 +0xa3
+k8s.io/client-go/rest/watch.(*Decoder).Decode(0xc004e886e0)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/rest/watch/decoder.go:49 +0x4b
+k8s.io/apimachinery/pkg/watch.(*StreamWatcher).receive(0xc002b50be0)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/watch/streamwatcher.go:114 +0xf8
+created by k8s.io/apimachinery/pkg/watch.NewStreamWatcherWithLogger in goroutine 21603
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/watch/streamwatcher.go:85 +0x149
+
+goroutine 726430 [select]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*Worker).run(0xc004438200, {0x2815270, 0xc0043d4000})
+	/workspace/internal/provider/processor/plan/worker.go:122 +0x6fe
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f6c0, {0x2815270, 0xc0043d4000}, {{0xc003c6bd40, 0x453472?}, {0xc003c6bde8?, 0xc003dc15c0?}}, 0xc000f7d320?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 182
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 608008 [select, 1348 minutes]:
+context.(*cancelCtx).propagateCancel.func2()
+	/usr/local/go/src/context/context.go:523 +0x98
+created by context.(*cancelCtx).propagateCancel in goroutine 235
+	/usr/local/go/src/context/context.go:522 +0x409
+
+goroutine 728445 [select, 8 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2.1()
+	/workspace/internal/provider/processor/requeue/processor.go:116 +0x111
+created by github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2 in goroutine 183
+	/workspace/internal/provider/processor/requeue/processor.go:112 +0x78d
+
+goroutine 726408 [select, 2 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/status.(*UpdateProcessor[...].func3.1()
+	/workspace/pkg/keyedworker/handler.go:64 +0x191
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283efe0, {0x2815270, 0xc000c73c20}, {{0xc0050fc6d8, 0x453472?}, {0xc0033f09b0?, 0x0?}}, 0xc001d2e4e0?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 726406
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 21595 [sync.Cond.Wait]:
+sync.runtime_notifyListWait(0xc001ad3a68, 0x2b696)
+	/usr/local/go/src/runtime/sema.go:606 +0x159
+sync.(*Cond).Wait(0xc004a4c940?)
+	/usr/local/go/src/sync/cond.go:71 +0x73
+k8s.io/client-go/tools/cache.(*RealFIFO).Pop(0xc001ad3a40, 0xc003425710)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/the_real_fifo.go:207 +0x8b
+k8s.io/client-go/tools/cache.(*controller).processLoop(0xc00130fd90, {0x2815510, 0xc00372db20})
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/controller.go:211 +0x5f
+k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext.func1({0x2815510?, 0xc00372db20?}, 0xc002a3fa70?)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:255 +0x51
+k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext({0x2815510, 0xc00372db20}, 0xc002573d70, {0x27f0f20, 0xc002a3fa70}, 0x1)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:256 +0xe5
+k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext({0x2815510, 0xc00372db20}, 0xc0038d0d70, 0x3b9aca00, 0x0, 0x1)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:223 +0x8f
+k8s.io/apimachinery/pkg/util/wait.UntilWithContext(...)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:172
+k8s.io/client-go/tools/cache.(*controller).RunWithContext(0xc00130fd90, {0x2815510, 0xc00372db20})
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/controller.go:183 +0x418
+k8s.io/client-go/tools/cache.(*sharedIndexInformer).RunWithContext(0xc00151b080, {0x2815510, 0xc00372db20})
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/shared_informer.go:587 +0x39a
+k8s.io/client-go/tools/cache.(*sharedIndexInformer).Run(0x2817ae0?, 0xc0038d0f70?)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/shared_informer.go:526 +0x1d
+sigs.k8s.io/controller-runtime/pkg/cache/internal.(*Cache).Start(0xc0034071f0, 0x0?)
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/cache/internal/informers.go:108 +0x72
+sigs.k8s.io/controller-runtime/pkg/cache/internal.(*Informers).startInformerLocked.func1()
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/cache/internal/informers.go:242 +0x75
+created by sigs.k8s.io/controller-runtime/pkg/cache/internal.(*Informers).startInformerLocked in goroutine 20838
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/cache/internal/informers.go:240 +0x87
+
+goroutine 732060 [select, 5 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2.1()
+	/workspace/internal/provider/processor/requeue/processor.go:116 +0x111
+created by github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2 in goroutine 183
+	/workspace/internal/provider/processor/requeue/processor.go:112 +0x78d
+
+goroutine 726432 [select]:
+github.com/ardikabs/hibernator/internal/provider/processor/status.(*UpdateProcessor[...].func3.1()
+	/workspace/pkg/keyedworker/handler.go:64 +0x191
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283efe0, {0x2815270, 0xc0043d40f0}, {{0xc003c6bd40, 0x453472?}, {0xc003c6bde8?, 0xc002520ae0?}}, 0xc00137c390?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 726430
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 726833 [select, 8 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/status.(*UpdateProcessor[...].func3.1()
+	/workspace/pkg/keyedworker/handler.go:64 +0x191
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283efe0, {0x2815270, 0xc004c93a40}, {{0xc004b947c8, 0x92ad28?}, {0xc004b94840?, 0xc000376be0?}}, 0xc00371dd40?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 726831
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 726507 [select, 3 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*Worker).run(0xc00134e100, {0x2815270, 0xc0043aa6e0})
+	/workspace/internal/provider/processor/plan/worker.go:122 +0x6fe
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f6c0, {0x2815270, 0xc0043aa6e0}, {{0xc0038bed08, 0x92ad28?}, {0xc0038bed80?, 0x93d8a5?}}, 0xc000998840?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 182
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 732715 [select, 3 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2.1()
+	/workspace/internal/provider/processor/requeue/processor.go:116 +0x111
+created by github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2 in goroutine 183
+	/workspace/internal/provider/processor/requeue/processor.go:112 +0x78d
+
+goroutine 21601 [chan receive, 7868 minutes]:
+k8s.io/client-go/tools/cache.(*sharedProcessor).run(0xc000b47900, {0x2815270, 0xc000b47a40})
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/shared_informer.go:893 +0x65
+k8s.io/client-go/tools/cache.(*sharedIndexInformer).RunWithContext.(*Group).StartWithContext.func4()
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:63 +0x1f
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:72 +0x4c
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 21595
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:70 +0x73
+
+goroutine 21599 [select, 7868 minutes]:
+reflect.rselect({0xc00318ff00, 0x3, 0x0?})
+	/usr/local/go/src/runtime/select.go:616 +0x3ce
+reflect.Select({0xc00130fce0?, 0x3, 0xc00318ffd0?})
+	/usr/local/go/src/reflect/value.go:2949 +0x5ca
+sigs.k8s.io/controller-runtime/pkg/internal/syncs.MergeChans[...].func2()
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/internal/syncs/syncs.go:34 +0x4f
+created by sigs.k8s.io/controller-runtime/pkg/internal/syncs.MergeChans[...] in goroutine 21595
+	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.0/pkg/internal/syncs/syncs.go:32 +0x3cc
+
+goroutine 21602 [chan receive, 7868 minutes]:
+k8s.io/client-go/tools/cache.(*controller).RunWithContext.func1()
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/controller.go:151 +0x2c
+created by k8s.io/client-go/tools/cache.(*controller).RunWithContext in goroutine 21595
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/controller.go:150 +0xdf
+
+goroutine 21603 [select]:
+k8s.io/client-go/tools/cache.handleAnyWatch({0x2815510, 0xc00372db20}, {0xc003d890e0?, 0x0?, 0x3bb1060?}, {0x27fc198, 0xc002b50be0}, {0x7f0b706712f8, 0xc001ad3a40}, {0x283e2d0, ...}, ...)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:892 +0x2b3
+k8s.io/client-go/tools/cache.handleWatch({0x2815510?, 0xc00372db20?}, {0xc003d890e0?, 0x0?, 0x3bb1060?}, {0x27fc198?, 0xc002b50be0?}, {0x7f0b706712f8?, 0xc001ad3a40?}, {0x283e2d0, ...}, ...)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:850 +0xea
+k8s.io/client-go/tools/cache.(*Reflector).watch(0xc000572c30, {0x2815510, 0xc00372db20}, {0x27fc198, 0xc002b50be0}, 0xc00033fce0)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:542 +0x60e
+k8s.io/client-go/tools/cache.(*Reflector).watchWithResync(0xc000572c30, {0x2815510, 0xc00372db20}, {0x0, 0x0})
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:482 +0x186
+k8s.io/client-go/tools/cache.(*Reflector).ListAndWatchWithContext(0xc000572c30, {0x2815510, 0xc00372db20})
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:437 +0x3f2
+k8s.io/client-go/tools/cache.(*Reflector).RunWithContext.func1()
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:360 +0x2e
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1({0x1a2c50e?, 0x41c8d4?})
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:233 +0x13
+k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext.func1({0x2815510?, 0xc00372db20?}, 0x41c900?)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:255 +0x51
+k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext({0x2815510, 0xc00372db20}, 0xc000fb3ea8, {0x27f0f40, 0xc000b47a90}, 0x1)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:256 +0xe5
+k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x281a1e0?, {0x27f0f40?, 0xc000b47a90?}, 0x72?, 0x12?)
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/backoff.go:233 +0x46
+k8s.io/client-go/tools/cache.(*Reflector).RunWithContext(0xc000572c30, {0x2815510, 0xc00372db20})
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:359 +0x22b
+k8s.io/client-go/tools/cache.(*controller).RunWithContext.(*Group).StartWithContext.func3()
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:63 +0x1f
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:72 +0x4c
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 21595
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:70 +0x73
+
+goroutine 21663 [select, 7868 minutes]:
+context.(*cancelCtx).propagateCancel.func2()
+	/usr/local/go/src/context/context.go:523 +0x98
+created by context.(*cancelCtx).propagateCancel in goroutine 21603
+	/usr/local/go/src/context/context.go:522 +0x409
+
+goroutine 730730 [select, 7 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2.1()
+	/workspace/internal/provider/processor/requeue/processor.go:116 +0x111
+created by github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2 in goroutine 183
+	/workspace/internal/provider/processor/requeue/processor.go:112 +0x78d
+
+goroutine 21664 [select, 206 minutes]:
+k8s.io/client-go/tools/cache.(*Reflector).startResync(0xc000572c30, {0x2815270, 0xc002653720}, 0xc00033fce0)
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:450 +0x12d
+k8s.io/client-go/tools/cache.(*Reflector).watchWithResync.func2()
+	/go/pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:480 +0x25
+k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:72 +0x4c
+created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 21603
+	/go/pkg/mod/k8s.io/apimachinery@v0.34.0/pkg/util/wait/wait.go:70 +0x73
+
+goroutine 727157 [select, 7 minutes]:
+github.com/ardikabs/hibernator/internal/notification.(*Dispatcher).workerFactory-fm.(*Dispatcher).workerFactory.func1({0x2815270, 0xc002c06c80})
+	/workspace/internal/notification/dispatcher.go:345 +0x2ce
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f560, {0x2815270, 0xc002c06c80}, {{{0xc003e79a28, 0x11}, {0xc003e79a10, 0x15}}, {0xc00054f330, 0x8}, {{0xc002450b40, ...}, ...}, ...}, ...)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c7
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 726519
+	/workspace/pkg/keyedworker/pool.go:312 +0x2c7
+
+goroutine 727334 [select, 7 minutes]:
+github.com/ardikabs/hibernator/internal/notification.(*Dispatcher).workerFactory-fm.(*Dispatcher).workerFactory.func1({0x2815270, 0xc003e74550})
+	/workspace/internal/notification/dispatcher.go:345 +0x2ce
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f560, {0x2815270, 0xc003e74550}, {{{0xc00482f440, 0x11}, {0xc00482f428, 0x14}}, {0xc0033f78e0, 0x8}, {{0xc002450b40, ...}, ...}, ...}, ...)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c7
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 726833
+	/workspace/pkg/keyedworker/pool.go:312 +0x2c7
+
+goroutine 726519 [select, 8 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/status.(*UpdateProcessor[...].func3.1()
+	/workspace/pkg/keyedworker/handler.go:64 +0x191
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283efe0, {0x2815270, 0xc00425fdb0}, {{0xc003fe4e40, 0x86c0e8?}, {0xc003fe4ed0?, 0x2815238?}}, 0xc0024b29f0?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 726517
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 726546 [select]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).loop(0xc003a641e0, {0x2815270, 0xc00375a690})
+	/workspace/internal/provider/processor/plan/timer.go:203 +0x177
+created by github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).Start in goroutine 726545
+	/workspace/internal/provider/processor/plan/timer.go:174 +0xd0
+
+goroutine 726898 [select, 8 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2.1()
+	/workspace/internal/provider/processor/requeue/processor.go:116 +0x111
+created by github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2 in goroutine 183
+	/workspace/internal/provider/processor/requeue/processor.go:112 +0x78d
+
+goroutine 727284 [select, 7 minutes]:
+github.com/ardikabs/hibernator/internal/notification.(*Dispatcher).workerFactory-fm.(*Dispatcher).workerFactory.func1({0x2815270, 0xc004030fa0})
+	/workspace/internal/notification/dispatcher.go:345 +0x2ce
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f560, {0x2815270, 0xc004030fa0}, {{{0xc003766df8, 0x11}, {0xc003766de0, 0x15}}, {0xc000afc410, 0x8}, {{0xc002450b40, ...}, ...}, ...}, ...)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c7
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 726839
+	/workspace/pkg/keyedworker/pool.go:312 +0x2c7
+
+goroutine 733332 [select]:
+google.golang.org/grpc/internal/transport.(*controlBuffer).get(0xc002675880, 0x1)
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/internal/transport/controlbuf.go:412 +0x108
+google.golang.org/grpc/internal/transport.(*loopyWriter).run(0xc00281a180)
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/internal/transport/controlbuf.go:575 +0x78
+google.golang.org/grpc/internal/transport.NewServerTransport.func2()
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/internal/transport/http2_server.go:336 +0xdc
+created by google.golang.org/grpc/internal/transport.NewServerTransport in goroutine 733331
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/internal/transport/http2_server.go:334 +0x189b
+
+goroutine 727391 [select]:
+google.golang.org/grpc/internal/transport.(*controlBuffer).get(0xc0035badc0, 0x1)
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/internal/transport/controlbuf.go:412 +0x108
+google.golang.org/grpc/internal/transport.(*loopyWriter).run(0xc005519d80)
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/internal/transport/controlbuf.go:575 +0x78
+google.golang.org/grpc/internal/transport.NewServerTransport.func2()
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/internal/transport/http2_server.go:336 +0xdc
+created by google.golang.org/grpc/internal/transport.NewServerTransport in goroutine 727390
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/internal/transport/http2_server.go:334 +0x189b
+
+goroutine 729119 [select, 8 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2.1()
+	/workspace/internal/provider/processor/requeue/processor.go:116 +0x111
+created by github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2 in goroutine 183
+	/workspace/internal/provider/processor/requeue/processor.go:112 +0x78d
+
+goroutine 726459 [select]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).loop(0xc0027a8820, {0x2815270, 0xc00425e0f0})
+	/workspace/internal/provider/processor/plan/timer.go:203 +0x177
+created by github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).Start in goroutine 726458
+	/workspace/internal/provider/processor/plan/timer.go:174 +0xd0
+
+goroutine 727395 [select]:
+google.golang.org/grpc/internal/transport.(*recvBufferReader).readMessageHeader(0xc003a18410, {0xc002e2fae0, 0x5, 0x5})
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/internal/transport/transport.go:176 +0x9e
+google.golang.org/grpc/internal/transport.(*recvBufferReader).ReadMessageHeader(0xc003a18410, {0xc002e2fae0?, 0xc003cc3040?, 0xc0049b4600?})
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/internal/transport/transport.go:145 +0x77
+google.golang.org/grpc/internal/transport.(*transportReader).ReadMessageHeader(0xc0053ad7c0, {0xc002e2fae0?, 0x23991e0?, 0xc0004854a0?})
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/internal/transport/transport.go:417 +0x25
+google.golang.org/grpc/internal/transport.(*Stream).ReadMessageHeader(0xc002d4fc20, {0xc002e2fae0, 0x5, 0x5})
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/internal/transport/transport.go:360 +0x9e
+google.golang.org/grpc.(*parser).recvMsg(0xc002e2fad0, 0x400000)
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/rpc_util.go:659 +0x3b
+google.golang.org/grpc.recvAndDecompress(0xc002e2fad0, {0x27f3e40, 0xc0049b4600}, {0x0, 0x0}, 0x400000, 0x0, {0x0, 0x0}, 0x1)
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/rpc_util.go:819 +0x97
+google.golang.org/grpc.recv(0x5?, {0x7f0b70487750, 0x3bd39e0}, {0x27f3e40?, 0xc0049b4600?}, {0x0?, 0x0?}, {0x22bccc0, 0xc003dda850}, 0x400000, ...)
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/rpc_util.go:902 +0xab
+google.golang.org/grpc.(*serverStream).RecvMsg(0xc000000b60, {0x22bccc0, 0xc003dda850})
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/stream.go:1760 +0x192
+google.golang.org/grpc.(*GenericServerStream[...]).Recv(0x2822200)
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/stream_interfaces.go:234 +0x4e
+github.com/ardikabs/hibernator/internal/streaming/server.(*ExecutionServiceServer).StreamLogs(0xc00053cbd0, {0x2822190, 0xc001518980})
+	/workspace/internal/streaming/server/service.go:103 +0x127
+github.com/ardikabs/hibernator/api/streaming/v1alpha1._ExecutionService_StreamLogs_Handler({0x2318f20?, 0xc00053cbd0}, {0x281a8c8, 0xc0053adaa0})
+	/workspace/api/streaming/v1alpha1/execution_grpc.pb.go:162 +0xd8
+github.com/ardikabs/hibernator/internal/streaming/server.NewServer.GRPCStreamInterceptor.func3({0x2318f20, 0xc00053cbd0}, {0x281b518, 0xc000000b60}, 0xc002760630, 0x25f1e08)
+	/workspace/internal/streaming/auth/interceptor.go:139 +0x2b9
+google.golang.org/grpc.(*Server).processStreamingRPC(0xc000338200, {0x2815238, 0xc002e2fa70}, 0xc0049b4600, 0xc0003e96b0, 0x3b84120, 0x0)
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/server.go:1702 +0x1253
+google.golang.org/grpc.(*Server).handleStream(0xc000338200, {0x2816060, 0xc003cc3040}, 0xc0049b4600)
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/server.go:1819 +0xb54
+google.golang.org/grpc.(*Server).serveStreams.func2.1()
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/server.go:1035 +0x7f
+created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 727409
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/server.go:1046 +0x11d
+
+goroutine 727486 [select, 5 minutes]:
+github.com/ardikabs/hibernator/internal/notification.(*Dispatcher).workerFactory-fm.(*Dispatcher).workerFactory.func1({0x2815270, 0xc001ea21e0})
+	/workspace/internal/notification/dispatcher.go:345 +0x2ce
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f560, {0x2815270, 0xc001ea21e0}, {{{0xc004b1a660, 0x11}, {0xc004842460, 0x1c}}, {0xc00415ac40, 0x8}, {{0xc002450b40, ...}, ...}, ...}, ...)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c7
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 726863
+	/workspace/pkg/keyedworker/pool.go:312 +0x2c7
+
+goroutine 726404 [select, 9 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).loop(0xc0031ef7c0, {0x2815270, 0xc000c739a0})
+	/workspace/internal/provider/processor/plan/timer.go:203 +0x177
+created by github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).Start in goroutine 726403
+	/workspace/internal/provider/processor/plan/timer.go:174 +0xd0
+
+goroutine 608003 [select, 1348 minutes]:
+context.(*cancelCtx).propagateCancel.func2()
+	/usr/local/go/src/context/context.go:523 +0x98
+created by context.(*cancelCtx).propagateCancel in goroutine 101
+	/usr/local/go/src/context/context.go:522 +0x409
+
+goroutine 733334 [IO wait]:
+internal/poll.runtime_pollWait(0x7f0b70515000, 0x72)
+	/usr/local/go/src/runtime/netpoll.go:351 +0x85
+internal/poll.(*pollDesc).wait(0xc00281a080?, 0xc001984000?, 0x0)
+	/usr/local/go/src/internal/poll/fd_poll_runtime.go:84 +0x27
+internal/poll.(*pollDesc).waitRead(...)
+	/usr/local/go/src/internal/poll/fd_poll_runtime.go:89
+internal/poll.(*FD).Read(0xc00281a080, {0xc001984000, 0x8000, 0x8000})
+	/usr/local/go/src/internal/poll/fd_unix.go:165 +0x279
+net.(*netFD).Read(0xc00281a080, {0xc001984000?, 0xc000d32c00?, 0x4140fe?})
+	/usr/local/go/src/net/fd_posix.go:68 +0x25
+net.(*conn).Read(0xc0032b3388, {0xc001984000?, 0x47e885?, 0xc0034753a8?})
+	/usr/local/go/src/net/net.go:196 +0x45
+bufio.(*Reader).Read(0xc000319d40, {0xc000001d24, 0x9, 0x4b23da?})
+	/usr/local/go/src/bufio/bufio.go:245 +0x197
+io.ReadAtLeast({0x27edea0, 0xc000319d40}, {0xc000001d24, 0x9, 0x9}, 0x9)
+	/usr/local/go/src/io/io.go:335 +0x8e
+io.ReadFull(...)
+	/usr/local/go/src/io/io.go:354
+golang.org/x/net/http2.readFrameHeader({0xc000001d24, 0x9, 0x1d0181c?}, {0x27edea0?, 0xc000319d40?})
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/frame.go:242 +0x65
+golang.org/x/net/http2.(*Framer).ReadFrameHeader(0xc000001ce0)
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/frame.go:505 +0x6b
+golang.org/x/net/http2.(*Framer).ReadFrame(0xc000001ce0)
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/frame.go:564 +0x18
+google.golang.org/grpc/internal/transport.(*http2Server).HandleStreams(0xc001883520, {0x2815238, 0xc002dfb9e0}, 0xc002dfba10)
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/internal/transport/http2_server.go:657 +0x105
+google.golang.org/grpc.(*Server).serveStreams(0xc000338200, {0x2814cd8?, 0x3bd39e0?}, {0x2816060, 0xc001883520}, {0x281e918?, 0xc0032b3388?})
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/server.go:1029 +0x3af
+google.golang.org/grpc.(*Server).handleRawConn.func1()
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/server.go:964 +0x56
+created by google.golang.org/grpc.(*Server).handleRawConn in goroutine 733331
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/server.go:963 +0x1cb
+
+goroutine 728534 [IO wait]:
+internal/poll.runtime_pollWait(0x7f0b70514800, 0x72)
+	/usr/local/go/src/runtime/netpoll.go:351 +0x85
+internal/poll.(*pollDesc).wait(0xc003d41780?, 0xc002a78000?, 0x0)
+	/usr/local/go/src/internal/poll/fd_poll_runtime.go:84 +0x27
+internal/poll.(*pollDesc).waitRead(...)
+	/usr/local/go/src/internal/poll/fd_poll_runtime.go:89
+internal/poll.(*FD).Read(0xc003d41780, {0xc002a78000, 0x8000, 0x8000})
+	/usr/local/go/src/internal/poll/fd_unix.go:165 +0x279
+net.(*netFD).Read(0xc003d41780, {0xc002a78000?, 0xc0049ddc00?, 0x414134?})
+	/usr/local/go/src/net/fd_posix.go:68 +0x25
+net.(*conn).Read(0xc002621b00, {0xc002a78000?, 0x47e885?, 0xc004eaa3e8?})
+	/usr/local/go/src/net/net.go:196 +0x45
+bufio.(*Reader).Read(0xc0016077a0, {0xc003a82824, 0x9, 0x4b23da?})
+	/usr/local/go/src/bufio/bufio.go:245 +0x197
+io.ReadAtLeast({0x27edea0, 0xc0016077a0}, {0xc003a82824, 0x9, 0x9}, 0x9)
+	/usr/local/go/src/io/io.go:335 +0x8e
+io.ReadFull(...)
+	/usr/local/go/src/io/io.go:354
+golang.org/x/net/http2.readFrameHeader({0xc003a82824, 0x9, 0x1d0181c?}, {0x27edea0?, 0xc0016077a0?})
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/frame.go:242 +0x65
+golang.org/x/net/http2.(*Framer).ReadFrameHeader(0xc003a827e0)
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/frame.go:505 +0x6b
+golang.org/x/net/http2.(*Framer).ReadFrame(0xc003a827e0)
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/frame.go:564 +0x18
+google.golang.org/grpc/internal/transport.(*http2Server).HandleStreams(0xc002bb31e0, {0x2815238, 0xc002ce59e0}, 0xc002ce5a10)
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/internal/transport/http2_server.go:657 +0x105
+google.golang.org/grpc.(*Server).serveStreams(0xc000338200, {0x2814cd8?, 0x3bd39e0?}, {0x2816060, 0xc002bb31e0}, {0x281e918?, 0xc002621b00?})
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/server.go:1029 +0x3af
+google.golang.org/grpc.(*Server).handleRawConn.func1()
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/server.go:964 +0x56
+created by google.golang.org/grpc.(*Server).handleRawConn in goroutine 728546
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/server.go:963 +0x1cb
+
+goroutine 733929 [select, 1 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2.1()
+	/workspace/internal/provider/processor/requeue/processor.go:116 +0x111
+created by github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2 in goroutine 183
+	/workspace/internal/provider/processor/requeue/processor.go:112 +0x78d
+
+goroutine 727138 [select, 8 minutes]:
+github.com/ardikabs/hibernator/internal/notification.(*Dispatcher).workerFactory-fm.(*Dispatcher).workerFactory.func1({0x2815270, 0xc002b512c0})
+	/workspace/internal/notification/dispatcher.go:345 +0x2ce
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f560, {0x2815270, 0xc002b512c0}, {{{0xc003e2bd40, 0x11}, {0xc003e2bd28, 0x16}}, {0xc0025a33a0, 0x8}, {{0xc002450b40, ...}, ...}, ...}, ...)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c7
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 726547
+	/workspace/pkg/keyedworker/pool.go:312 +0x2c7
+
+goroutine 728533 [select, 8 minutes]:
+google.golang.org/grpc/internal/transport.(*http2Server).keepalive(0xc002bb31e0)
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/internal/transport/http2_server.go:1197 +0x1ea
+created by google.golang.org/grpc/internal/transport.NewServerTransport in goroutine 728546
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/internal/transport/http2_server.go:357 +0x18dd
+
+goroutine 726499 [select, 8 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).loop(0xc001ebb720, {0x2815270, 0xc004ded1d0})
+	/workspace/internal/provider/processor/plan/timer.go:203 +0x177
+created by github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).Start in goroutine 726498
+	/workspace/internal/provider/processor/plan/timer.go:174 +0xd0
+
+goroutine 728532 [select]:
+google.golang.org/grpc/internal/transport.(*controlBuffer).get(0xc0019bf4c0, 0x1)
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/internal/transport/controlbuf.go:412 +0x108
+google.golang.org/grpc/internal/transport.(*loopyWriter).run(0xc001e7cf00)
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/internal/transport/controlbuf.go:575 +0x78
+google.golang.org/grpc/internal/transport.NewServerTransport.func2()
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/internal/transport/http2_server.go:336 +0xdc
+created by google.golang.org/grpc/internal/transport.NewServerTransport in goroutine 728546
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/internal/transport/http2_server.go:334 +0x189b
+
+goroutine 727305 [IO wait]:
+internal/poll.runtime_pollWait(0x7f0b70514c00, 0x72)
+	/usr/local/go/src/runtime/netpoll.go:351 +0x85
+internal/poll.(*pollDesc).wait(0xc003614e00?, 0xc0010e8000?, 0x0)
+	/usr/local/go/src/internal/poll/fd_poll_runtime.go:84 +0x27
+internal/poll.(*pollDesc).waitRead(...)
+	/usr/local/go/src/internal/poll/fd_poll_runtime.go:89
+internal/poll.(*FD).Read(0xc003614e00, {0xc0010e8000, 0x8000, 0x8000})
+	/usr/local/go/src/internal/poll/fd_unix.go:165 +0x279
+net.(*netFD).Read(0xc003614e00, {0xc0010e8000?, 0xc0038dec00?, 0x4140fe?})
+	/usr/local/go/src/net/fd_posix.go:68 +0x25
+net.(*conn).Read(0xc002c921f8, {0xc0010e8000?, 0x47e885?, 0xc004a646f8?})
+	/usr/local/go/src/net/net.go:196 +0x45
+bufio.(*Reader).Read(0xc002907980, {0xc000000044, 0x9, 0x4b23da?})
+	/usr/local/go/src/bufio/bufio.go:245 +0x197
+io.ReadAtLeast({0x27edea0, 0xc002907980}, {0xc000000044, 0x9, 0x9}, 0x9)
+	/usr/local/go/src/io/io.go:335 +0x8e
+io.ReadFull(...)
+	/usr/local/go/src/io/io.go:354
+golang.org/x/net/http2.readFrameHeader({0xc000000044, 0x9, 0x1d0181c?}, {0x27edea0?, 0xc002907980?})
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/frame.go:242 +0x65
+golang.org/x/net/http2.(*Framer).ReadFrameHeader(0xc000000000)
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/frame.go:505 +0x6b
+golang.org/x/net/http2.(*Framer).ReadFrame(0xc000000000)
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/frame.go:564 +0x18
+google.golang.org/grpc/internal/transport.(*http2Server).HandleStreams(0xc001db69c0, {0x2815238, 0xc000ea7200}, 0xc000ea7230)
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/internal/transport/http2_server.go:657 +0x105
+google.golang.org/grpc.(*Server).serveStreams(0xc000338200, {0x2814cd8?, 0x3bd39e0?}, {0x2816060, 0xc001db69c0}, {0x281e918?, 0xc002c921f8?})
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/server.go:1029 +0x3af
+google.golang.org/grpc.(*Server).handleRawConn.func1()
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/server.go:964 +0x56
+created by google.golang.org/grpc.(*Server).handleRawConn in goroutine 727302
+	/go/pkg/mod/google.golang.org/grpc@v1.72.2/server.go:963 +0x1cb
+
+goroutine 734534 [IO wait]:
+internal/poll.runtime_pollWait(0x7f0b70515200, 0x72)
+	/usr/local/go/src/runtime/netpoll.go:351 +0x85
+internal/poll.(*pollDesc).wait(0xc002aaf500?, 0xc0022d4000?, 0x0)
+	/usr/local/go/src/internal/poll/fd_poll_runtime.go:84 +0x27
+internal/poll.(*pollDesc).waitRead(...)
+	/usr/local/go/src/internal/poll/fd_poll_runtime.go:89
+internal/poll.(*FD).Read(0xc002aaf500, {0xc0022d4000, 0xa000, 0xa000})
+	/usr/local/go/src/internal/poll/fd_unix.go:165 +0x279
+net.(*netFD).Read(0xc002aaf500, {0xc0022d4000?, 0xc0022d4000?, 0x5?})
+	/usr/local/go/src/net/fd_posix.go:68 +0x25
+net.(*conn).Read(0xc002c93b68, {0xc0022d4000?, 0x7f0b705a6420?, 0x7f0bb74855c0?})
+	/usr/local/go/src/net/net.go:196 +0x45
+crypto/tls.(*atLeastReader).Read(0xc000c9df50, {0xc0022d4000?, 0x9ffb?, 0x8?})
+	/usr/local/go/src/crypto/tls/conn.go:819 +0x3b
+bytes.(*Buffer).ReadFrom(0xc0019969a8, {0x27ef560, 0xc000c9df50})
+	/usr/local/go/src/bytes/buffer.go:217 +0x98
+crypto/tls.(*Conn).readFromUntil(0xc001996708, {0x27ef680, 0xc002c93b68}, 0xc0054709d0?)
+	/usr/local/go/src/crypto/tls/conn.go:841 +0xde
+crypto/tls.(*Conn).readRecordOrCCS(0xc001996708, 0x0)
+	/usr/local/go/src/crypto/tls/conn.go:630 +0x3db
+crypto/tls.(*Conn).readRecord(...)
+	/usr/local/go/src/crypto/tls/conn.go:592
+crypto/tls.(*Conn).Read(0xc001996708, {0xc00108c000, 0x1000, 0x924c00?})
+	/usr/local/go/src/crypto/tls/conn.go:1397 +0x145
+bufio.(*Reader).Read(0xc0020dcd20, {0xc003b73624, 0x9, 0x9326ae?})
+	/usr/local/go/src/bufio/bufio.go:245 +0x197
+io.ReadAtLeast({0x27edea0, 0xc0020dcd20}, {0xc003b73624, 0x9, 0x9}, 0x9)
+	/usr/local/go/src/io/io.go:335 +0x8e
+io.ReadFull(...)
+	/usr/local/go/src/io/io.go:354
+golang.org/x/net/http2.readFrameHeader({0xc003b73624, 0x9, 0xc00000002d?}, {0x27edea0?, 0xc0020dcd20?})
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/frame.go:242 +0x65
+golang.org/x/net/http2.(*Framer).ReadFrameHeader(0xc003b735e0)
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/frame.go:505 +0x6b
+golang.org/x/net/http2.(*Framer).ReadFrame(0xc003b735e0)
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/frame.go:564 +0x18
+golang.org/x/net/http2.(*clientConnReadLoop).run(0xc005470fa8)
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/transport.go:2258 +0xca
+golang.org/x/net/http2.(*ClientConn).readLoop(0xc0010c7a40)
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/transport.go:2127 +0x52
+created by golang.org/x/net/http2.(*Transport).newClientConn in goroutine 734533
+	/go/pkg/mod/golang.org/x/net@v0.49.0/http2/transport.go:880 +0xda5
+
+goroutine 726844 [select, 8 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).loop(0xc0038b1360, {0x2815270, 0xc0031f1090})
+	/workspace/internal/provider/processor/plan/timer.go:203 +0x177
+created by github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).Start in goroutine 726843
+	/workspace/internal/provider/processor/plan/timer.go:174 +0xd0
+
+goroutine 726414 [select]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).loop(0xc004724aa0, {0x2815270, 0xc00223a0a0})
+	/workspace/internal/provider/processor/plan/timer.go:203 +0x177
+created by github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).Start in goroutine 726413
+	/workspace/internal/provider/processor/plan/timer.go:174 +0xd0
+
+goroutine 726832 [select]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).loop(0xc0014d7720, {0x2815270, 0xc004c939f0})
+	/workspace/internal/provider/processor/plan/timer.go:203 +0x177
+created by github.com/ardikabs/hibernator/internal/provider/processor/plan.(*TimerSet).Start in goroutine 726831
+	/workspace/internal/provider/processor/plan/timer.go:174 +0xd0
+
+goroutine 726899 [select]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*Worker).run(0xc00370e100, {0x2815270, 0xc00023c410})
+	/workspace/internal/provider/processor/plan/worker.go:122 +0x6fe
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f6c0, {0x2815270, 0xc00023c410}, {{0xc0032aecd8, 0x92ad28?}, {0xc0032af080?, 0x8607c5?}}, 0xc00123e480?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 182
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 726498 [select, 8 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/plan.(*Worker).run(0xc004911300, {0x2815270, 0xc004ded130})
+	/workspace/internal/provider/processor/plan/worker.go:122 +0x6fe
+github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).runEntry(0x283f6c0, {0x2815270, 0xc004ded130}, {{0xc0036836b0, 0x92ad28?}, {0xc003683728?, 0xc00130f748?}}, 0xc0011a9410?)
+	/workspace/pkg/keyedworker/pool.go:392 +0x1c3
+created by github.com/ardikabs/hibernator/pkg/keyedworker.(*Pool[...]).ensureRunning in goroutine 182
+	/workspace/pkg/keyedworker/pool.go:312 +0x2a5
+
+goroutine 729157 [select, 8 minutes]:
+github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2.1()
+	/workspace/internal/provider/processor/requeue/processor.go:116 +0x111
+created by github.com/ardikabs/hibernator/internal/provider/processor/requeue.(*PlanRequeueProcessor).Start.func2 in goroutine 183
+	/workspace/internal/provider/processor/requeue/processor.go:112 +0x78d


### PR DESCRIPTION
The markJobAsStale goroutine was launched with a pointer to a range-loop variable (&job), causing it to mutate a Labels map shared with the original jobs slice. Since JobExistsForTarget reads from that same slice concurrently, this triggered a fatal "concurrent map read and map write" panic.
Pass job.DeepCopy() instead so the async goroutine mutates an isolated copy of the Job object.